### PR TITLE
Reformat elevation tokens

### DIFF
--- a/styles/src/tokens.json
+++ b/styles/src/tokens.json
@@ -663,16 +663,7 @@
     },
     "elevation": {
       "0": {
-        "value": [
-          {
-            "color": "none",
-            "type": "dropShadow",
-            "x": "",
-            "y": "",
-            "blur": "",
-            "spread": ""
-          }
-        ],
+        "value": "none",
         "type": "boxShadow"
       },
       "1": {


### PR DESCRIPTION
I'd like the elevation tokens to have this shape to be a bit more consistent with the rest of our system. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1--canary.10.6ffc3bf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @oxide/design-system@0.1.1--canary.10.6ffc3bf.0
  # or 
  yarn add @oxide/design-system@0.1.1--canary.10.6ffc3bf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
