### PR TITLE
Fix icon publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "files": [
     "styles/dist/*.css",
     "styles/dist/tailwind-tokens.js",
-    "icons/**.tsx"
+    "icons/**.svg"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
The files entry in package.json was incorrect which cause the icons to not be published. 