### PR TITLE
Fallback did not work in older chrome versions

### DIFF
--- a/scripts/convert-tokens.ts
+++ b/scripts/convert-tokens.ts
@@ -217,10 +217,11 @@ const makeColorUtility = (
 
         return `
           ${description}
-          '.${color.name.replace(tokenPrefix, classPrefix)}': { 
-            ${properties.map(
-              (prop) => `'${prop}': ['var(--${color.name})', 'var(--${color.name}-p3)']`,
-            )},
+          '.${color.name.replace(tokenPrefix, classPrefix)}': {
+            ${properties.map((prop) => `'${prop}': 'var(--${color.name})'`)},
+            '@supports (color: color(display-p3 1 1 1))': {
+              ${properties.map((prop) => `'${prop}': 'var(--${color.name}-p3)'`)},
+            }
           }
         `
       })

--- a/styles/dist/tailwind-tokens.js
+++ b/styles/dist/tailwind-tokens.js
@@ -124,1977 +124,2835 @@ module.exports.textUtilities = {
 
 module.exports.colorUtilities = {
   '.text-default': {
-    color: ['var(--content-default)', 'var(--content-default-p3)'],
+    color: 'var(--content-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-default-p3)',
+    },
   },
   '.text-secondary': {
-    color: ['var(--content-secondary)', 'var(--content-secondary-p3)'],
+    color: 'var(--content-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-secondary-p3)',
+    },
   },
   '.text-tertiary': {
-    color: ['var(--content-tertiary)', 'var(--content-tertiary-p3)'],
+    color: 'var(--content-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-tertiary-p3)',
+    },
   },
   '.text-quaternary': {
-    color: ['var(--content-quaternary)', 'var(--content-quaternary-p3)'],
+    color: 'var(--content-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-quaternary-p3)',
+    },
   },
   '.text-quinary': {
-    color: ['var(--content-quinary)', 'var(--content-quinary-p3)'],
+    color: 'var(--content-quinary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-quinary-p3)',
+    },
   },
   '.text-disabled': {
-    color: ['var(--content-disabled)', 'var(--content-disabled-p3)'],
+    color: 'var(--content-disabled)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-disabled-p3)',
+    },
   },
   '.text-accent': {
-    color: ['var(--content-accent)', 'var(--content-accent-p3)'],
+    color: 'var(--content-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-accent-p3)',
+    },
   },
   '.text-accent-secondary': {
-    color: ['var(--content-accent-secondary)', 'var(--content-accent-secondary-p3)'],
+    color: 'var(--content-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-accent-secondary-p3)',
+    },
   },
   '.text-accent-tertiary': {
-    color: ['var(--content-accent-tertiary)', 'var(--content-accent-tertiary-p3)'],
+    color: 'var(--content-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-accent-tertiary-p3)',
+    },
   },
   '.text-accent-disabled': {
-    color: ['var(--content-accent-disabled)', 'var(--content-accent-disabled-p3)'],
+    color: 'var(--content-accent-disabled)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-accent-disabled-p3)',
+    },
   },
   '.text-destructive': {
-    color: ['var(--content-destructive)', 'var(--content-destructive-p3)'],
+    color: 'var(--content-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-destructive-p3)',
+    },
   },
   '.text-destructive-secondary': {
-    color: [
-      'var(--content-destructive-secondary)',
-      'var(--content-destructive-secondary-p3)',
-    ],
+    color: 'var(--content-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-destructive-secondary-p3)',
+    },
   },
   '.text-destructive-tertiary': {
-    color: [
-      'var(--content-destructive-tertiary)',
-      'var(--content-destructive-tertiary-p3)',
-    ],
+    color: 'var(--content-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-destructive-tertiary-p3)',
+    },
   },
   '.text-destructive-disabled': {
-    color: [
-      'var(--content-destructive-disabled)',
-      'var(--content-destructive-disabled-p3)',
-    ],
+    color: 'var(--content-destructive-disabled)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-destructive-disabled-p3)',
+    },
   },
   '.text-success': {
-    color: ['var(--content-success)', 'var(--content-success-p3)'],
+    color: 'var(--content-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-success-p3)',
+    },
   },
   '.text-success-secondary': {
-    color: ['var(--content-success-secondary)', 'var(--content-success-secondary-p3)'],
+    color: 'var(--content-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-success-secondary-p3)',
+    },
   },
   '.text-success-tertiary': {
-    color: ['var(--content-success-tertiary)', 'var(--content-success-tertiary-p3)'],
+    color: 'var(--content-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-success-tertiary-p3)',
+    },
   },
   '.text-success-disabled': {
-    color: ['var(--content-success-disabled)', 'var(--content-success-disabled-p3)'],
+    color: 'var(--content-success-disabled)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-success-disabled-p3)',
+    },
   },
   '.text-error': {
-    color: ['var(--content-error)', 'var(--content-error-p3)'],
+    color: 'var(--content-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-error-p3)',
+    },
   },
   '.text-error-secondary': {
-    color: ['var(--content-error-secondary)', 'var(--content-error-secondary-p3)'],
+    color: 'var(--content-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-error-secondary-p3)',
+    },
   },
   '.text-error-tertiary': {
-    color: ['var(--content-error-tertiary)', 'var(--content-error-tertiary-p3)'],
+    color: 'var(--content-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-error-tertiary-p3)',
+    },
   },
   '.text-error-disabled': {
-    color: ['var(--content-error-disabled)', 'var(--content-error-disabled-p3)'],
+    color: 'var(--content-error-disabled)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-error-disabled-p3)',
+    },
   },
   '.text-notice': {
-    color: ['var(--content-notice)', 'var(--content-notice-p3)'],
+    color: 'var(--content-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-notice-p3)',
+    },
   },
   '.text-notice-secondary': {
-    color: ['var(--content-notice-secondary)', 'var(--content-notice-secondary-p3)'],
+    color: 'var(--content-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-notice-secondary-p3)',
+    },
   },
   '.text-notice-tertiary': {
-    color: ['var(--content-notice-tertiary)', 'var(--content-notice-tertiary-p3)'],
+    color: 'var(--content-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-notice-tertiary-p3)',
+    },
   },
   '.text-notice-disabled': {
-    color: ['var(--content-notice-disabled)', 'var(--content-notice-disabled-p3)'],
+    color: 'var(--content-notice-disabled)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-notice-disabled-p3)',
+    },
   },
   '.text-inverse': {
-    color: ['var(--content-inverse)', 'var(--content-inverse-p3)'],
+    color: 'var(--content-inverse)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-inverse-p3)',
+    },
   },
   '.text-inverse-raise': {
-    color: ['var(--content-inverse-raise)', 'var(--content-inverse-raise-p3)'],
+    color: 'var(--content-inverse-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-inverse-raise-p3)',
+    },
   },
   '.text-inverse-secondary': {
-    color: ['var(--content-inverse-secondary)', 'var(--content-inverse-secondary-p3)'],
+    color: 'var(--content-inverse-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-inverse-secondary-p3)',
+    },
   },
   '.text-info': {
-    color: ['var(--content-info)', 'var(--content-info-p3)'],
+    color: 'var(--content-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-info-p3)',
+    },
   },
   '.text-info-secondary': {
-    color: ['var(--content-info-secondary)', 'var(--content-info-secondary-p3)'],
+    color: 'var(--content-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-info-secondary-p3)',
+    },
   },
   '.text-info-tertiary': {
-    color: ['var(--content-info-tertiary)', 'var(--content-info-tertiary-p3)'],
+    color: 'var(--content-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-info-tertiary-p3)',
+    },
   },
   '.text-info-disabled': {
-    color: ['var(--content-info-disabled)', 'var(--content-info-disabled-p3)'],
+    color: 'var(--content-info-disabled)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--content-info-disabled-p3)',
+    },
   },
   '.text-accent-100': {
-    color: ['var(--theme-accent-100)', 'var(--theme-accent-100-p3)'],
+    color: 'var(--theme-accent-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-accent-100-p3)',
+    },
   },
   '.text-accent-200': {
-    color: ['var(--theme-accent-200)', 'var(--theme-accent-200-p3)'],
+    color: 'var(--theme-accent-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-accent-200-p3)',
+    },
   },
   '.text-accent-300': {
-    color: ['var(--theme-accent-300)', 'var(--theme-accent-300-p3)'],
+    color: 'var(--theme-accent-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-accent-300-p3)',
+    },
   },
   '.text-accent-400': {
-    color: ['var(--theme-accent-400)', 'var(--theme-accent-400-p3)'],
+    color: 'var(--theme-accent-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-accent-400-p3)',
+    },
   },
   '.text-accent-500': {
-    color: ['var(--theme-accent-500)', 'var(--theme-accent-500-p3)'],
+    color: 'var(--theme-accent-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-accent-500-p3)',
+    },
   },
   '.text-accent-600': {
-    color: ['var(--theme-accent-600)', 'var(--theme-accent-600-p3)'],
+    color: 'var(--theme-accent-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-accent-600-p3)',
+    },
   },
   '.text-accent-700': {
-    color: ['var(--theme-accent-700)', 'var(--theme-accent-700-p3)'],
+    color: 'var(--theme-accent-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-accent-700-p3)',
+    },
   },
   '.text-accent-800': {
-    color: ['var(--theme-accent-800)', 'var(--theme-accent-800-p3)'],
+    color: 'var(--theme-accent-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-accent-800-p3)',
+    },
   },
   '.text-destructive-100': {
-    color: ['var(--theme-destructive-100)', 'var(--theme-destructive-100-p3)'],
+    color: 'var(--theme-destructive-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-destructive-100-p3)',
+    },
   },
   '.text-destructive-200': {
-    color: ['var(--theme-destructive-200)', 'var(--theme-destructive-200-p3)'],
+    color: 'var(--theme-destructive-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-destructive-200-p3)',
+    },
   },
   '.text-destructive-300': {
-    color: ['var(--theme-destructive-300)', 'var(--theme-destructive-300-p3)'],
+    color: 'var(--theme-destructive-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-destructive-300-p3)',
+    },
   },
   '.text-destructive-400': {
-    color: ['var(--theme-destructive-400)', 'var(--theme-destructive-400-p3)'],
+    color: 'var(--theme-destructive-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-destructive-400-p3)',
+    },
   },
   '.text-destructive-500': {
-    color: ['var(--theme-destructive-500)', 'var(--theme-destructive-500-p3)'],
+    color: 'var(--theme-destructive-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-destructive-500-p3)',
+    },
   },
   '.text-destructive-600': {
-    color: ['var(--theme-destructive-600)', 'var(--theme-destructive-600-p3)'],
+    color: 'var(--theme-destructive-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-destructive-600-p3)',
+    },
   },
   '.text-destructive-700': {
-    color: ['var(--theme-destructive-700)', 'var(--theme-destructive-700-p3)'],
+    color: 'var(--theme-destructive-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-destructive-700-p3)',
+    },
   },
   '.text-destructive-800': {
-    color: ['var(--theme-destructive-800)', 'var(--theme-destructive-800-p3)'],
+    color: 'var(--theme-destructive-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-destructive-800-p3)',
+    },
   },
   '.text-success-100': {
-    color: ['var(--theme-success-100)', 'var(--theme-success-100-p3)'],
+    color: 'var(--theme-success-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-success-100-p3)',
+    },
   },
   '.text-success-200': {
-    color: ['var(--theme-success-200)', 'var(--theme-success-200-p3)'],
+    color: 'var(--theme-success-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-success-200-p3)',
+    },
   },
   '.text-success-300': {
-    color: ['var(--theme-success-300)', 'var(--theme-success-300-p3)'],
+    color: 'var(--theme-success-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-success-300-p3)',
+    },
   },
   '.text-success-400': {
-    color: ['var(--theme-success-400)', 'var(--theme-success-400-p3)'],
+    color: 'var(--theme-success-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-success-400-p3)',
+    },
   },
   '.text-success-500': {
-    color: ['var(--theme-success-500)', 'var(--theme-success-500-p3)'],
+    color: 'var(--theme-success-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-success-500-p3)',
+    },
   },
   '.text-success-600': {
-    color: ['var(--theme-success-600)', 'var(--theme-success-600-p3)'],
+    color: 'var(--theme-success-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-success-600-p3)',
+    },
   },
   '.text-success-700': {
-    color: ['var(--theme-success-700)', 'var(--theme-success-700-p3)'],
+    color: 'var(--theme-success-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-success-700-p3)',
+    },
   },
   '.text-success-800': {
-    color: ['var(--theme-success-800)', 'var(--theme-success-800-p3)'],
+    color: 'var(--theme-success-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-success-800-p3)',
+    },
   },
   '.text-error-100': {
-    color: ['var(--theme-error-100)', 'var(--theme-error-100-p3)'],
+    color: 'var(--theme-error-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-error-100-p3)',
+    },
   },
   '.text-error-200': {
-    color: ['var(--theme-error-200)', 'var(--theme-error-200-p3)'],
+    color: 'var(--theme-error-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-error-200-p3)',
+    },
   },
   '.text-error-300': {
-    color: ['var(--theme-error-300)', 'var(--theme-error-300-p3)'],
+    color: 'var(--theme-error-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-error-300-p3)',
+    },
   },
   '.text-error-400': {
-    color: ['var(--theme-error-400)', 'var(--theme-error-400-p3)'],
+    color: 'var(--theme-error-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-error-400-p3)',
+    },
   },
   '.text-error-500': {
-    color: ['var(--theme-error-500)', 'var(--theme-error-500-p3)'],
+    color: 'var(--theme-error-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-error-500-p3)',
+    },
   },
   '.text-error-600': {
-    color: ['var(--theme-error-600)', 'var(--theme-error-600-p3)'],
+    color: 'var(--theme-error-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-error-600-p3)',
+    },
   },
   '.text-error-700': {
-    color: ['var(--theme-error-700)', 'var(--theme-error-700-p3)'],
+    color: 'var(--theme-error-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-error-700-p3)',
+    },
   },
   '.text-error-800': {
-    color: ['var(--theme-error-800)', 'var(--theme-error-800-p3)'],
+    color: 'var(--theme-error-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-error-800-p3)',
+    },
   },
   '.text-notice-100': {
-    color: ['var(--theme-notice-100)', 'var(--theme-notice-100-p3)'],
+    color: 'var(--theme-notice-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-notice-100-p3)',
+    },
   },
   '.text-notice-200': {
-    color: ['var(--theme-notice-200)', 'var(--theme-notice-200-p3)'],
+    color: 'var(--theme-notice-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-notice-200-p3)',
+    },
   },
   '.text-notice-300': {
-    color: ['var(--theme-notice-300)', 'var(--theme-notice-300-p3)'],
+    color: 'var(--theme-notice-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-notice-300-p3)',
+    },
   },
   '.text-notice-400': {
-    color: ['var(--theme-notice-400)', 'var(--theme-notice-400-p3)'],
+    color: 'var(--theme-notice-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-notice-400-p3)',
+    },
   },
   '.text-notice-500': {
-    color: ['var(--theme-notice-500)', 'var(--theme-notice-500-p3)'],
+    color: 'var(--theme-notice-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-notice-500-p3)',
+    },
   },
   '.text-notice-600': {
-    color: ['var(--theme-notice-600)', 'var(--theme-notice-600-p3)'],
+    color: 'var(--theme-notice-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-notice-600-p3)',
+    },
   },
   '.text-notice-700': {
-    color: ['var(--theme-notice-700)', 'var(--theme-notice-700-p3)'],
+    color: 'var(--theme-notice-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-notice-700-p3)',
+    },
   },
   '.text-notice-800': {
-    color: ['var(--theme-notice-800)', 'var(--theme-notice-800-p3)'],
+    color: 'var(--theme-notice-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-notice-800-p3)',
+    },
   },
   '.text-info-100': {
-    color: ['var(--theme-info-100)', 'var(--theme-info-100-p3)'],
+    color: 'var(--theme-info-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-info-100-p3)',
+    },
   },
   '.text-info-200': {
-    color: ['var(--theme-info-200)', 'var(--theme-info-200-p3)'],
+    color: 'var(--theme-info-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-info-200-p3)',
+    },
   },
   '.text-info-300': {
-    color: ['var(--theme-info-300)', 'var(--theme-info-300-p3)'],
+    color: 'var(--theme-info-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-info-300-p3)',
+    },
   },
   '.text-info-400': {
-    color: ['var(--theme-info-400)', 'var(--theme-info-400-p3)'],
+    color: 'var(--theme-info-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-info-400-p3)',
+    },
   },
   '.text-info-500': {
-    color: ['var(--theme-info-500)', 'var(--theme-info-500-p3)'],
+    color: 'var(--theme-info-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-info-500-p3)',
+    },
   },
   '.text-info-600': {
-    color: ['var(--theme-info-600)', 'var(--theme-info-600-p3)'],
+    color: 'var(--theme-info-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-info-600-p3)',
+    },
   },
   '.text-info-700': {
-    color: ['var(--theme-info-700)', 'var(--theme-info-700-p3)'],
+    color: 'var(--theme-info-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-info-700-p3)',
+    },
   },
   '.text-info-800': {
-    color: ['var(--theme-info-800)', 'var(--theme-info-800-p3)'],
+    color: 'var(--theme-info-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      color: 'var(--theme-info-800-p3)',
+    },
   },
   '.bg-default': {
-    'background-color': ['var(--surface-default)', 'var(--surface-default-p3)'],
+    'background-color': 'var(--surface-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-default-p3)',
+    },
   },
   '.bg-hover': {
-    'background-color': ['var(--surface-hover)', 'var(--surface-hover-p3)'],
+    'background-color': 'var(--surface-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-hover-p3)',
+    },
   },
   '.bg-raise': {
-    'background-color': ['var(--surface-raise)', 'var(--surface-raise-p3)'],
+    'background-color': 'var(--surface-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-raise-p3)',
+    },
   },
   '.bg-secondary': {
-    'background-color': ['var(--surface-secondary)', 'var(--surface-secondary-p3)'],
+    'background-color': 'var(--surface-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-secondary-p3)',
+    },
   },
   '.bg-tertiary': {
-    'background-color': ['var(--surface-tertiary)', 'var(--surface-tertiary-p3)'],
+    'background-color': 'var(--surface-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-tertiary-p3)',
+    },
   },
   '.bg-disabled': {
-    'background-color': ['var(--surface-disabled)', 'var(--surface-disabled-p3)'],
+    'background-color': 'var(--surface-disabled)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-disabled-p3)',
+    },
   },
   /* Command menu backdrop */
   '.bg-scrim': {
-    'background-color': ['var(--surface-scrim)', 'var(--surface-scrim-p3)'],
+    'background-color': 'var(--surface-scrim)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-scrim-p3)',
+    },
   },
   '.bg-accent': {
-    'background-color': ['var(--surface-accent)', 'var(--surface-accent-p3)'],
+    'background-color': 'var(--surface-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-accent-p3)',
+    },
   },
   '.bg-accent-hover': {
-    'background-color': ['var(--surface-accent-hover)', 'var(--surface-accent-hover-p3)'],
+    'background-color': 'var(--surface-accent-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-accent-hover-p3)',
+    },
   },
   '.bg-accent-secondary': {
-    'background-color': [
-      'var(--surface-accent-secondary)',
-      'var(--surface-accent-secondary-p3)',
-    ],
+    'background-color': 'var(--surface-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-accent-secondary-p3)',
+    },
   },
   '.bg-accent-secondary-hover': {
-    'background-color': [
-      'var(--surface-accent-secondary-hover)',
-      'var(--surface-accent-secondary-hover-p3)',
-    ],
+    'background-color': 'var(--surface-accent-secondary-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-accent-secondary-hover-p3)',
+    },
   },
   '.bg-destructive': {
-    'background-color': ['var(--surface-destructive)', 'var(--surface-destructive-p3)'],
+    'background-color': 'var(--surface-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-destructive-p3)',
+    },
   },
   '.bg-destructive-hover': {
-    'background-color': [
-      'var(--surface-destructive-hover)',
-      'var(--surface-destructive-hover-p3)',
-    ],
+    'background-color': 'var(--surface-destructive-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-destructive-hover-p3)',
+    },
   },
   '.bg-destructive-secondary': {
-    'background-color': [
-      'var(--surface-destructive-secondary)',
-      'var(--surface-destructive-secondary-p3)',
-    ],
+    'background-color': 'var(--surface-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-destructive-secondary-p3)',
+    },
   },
   '.bg-destructive-secondary-hover': {
-    'background-color': [
-      'var(--surface-destructive-secondary-hover)',
-      'var(--surface-destructive-secondary-hover-p3)',
-    ],
+    'background-color': 'var(--surface-destructive-secondary-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-destructive-secondary-hover-p3)',
+    },
   },
   '.bg-notice': {
-    'background-color': ['var(--surface-notice)', 'var(--surface-notice-p3)'],
+    'background-color': 'var(--surface-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-notice-p3)',
+    },
   },
   '.bg-notice-hover': {
-    'background-color': ['var(--surface-notice-hover)', 'var(--surface-notice-hover-p3)'],
+    'background-color': 'var(--surface-notice-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-notice-hover-p3)',
+    },
   },
   '.bg-notice-secondary': {
-    'background-color': [
-      'var(--surface-notice-secondary)',
-      'var(--surface-notice-secondary-p3)',
-    ],
+    'background-color': 'var(--surface-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-notice-secondary-p3)',
+    },
   },
   '.bg-notice-secondary-hover': {
-    'background-color': [
-      'var(--surface-notice-secondary-hover)',
-      'var(--surface-notice-secondary-hover-p3)',
-    ],
+    'background-color': 'var(--surface-notice-secondary-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-notice-secondary-hover-p3)',
+    },
   },
   '.bg-success': {
-    'background-color': ['var(--surface-success)', 'var(--surface-success-p3)'],
+    'background-color': 'var(--surface-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-success-p3)',
+    },
   },
   '.bg-success-secondary': {
-    'background-color': [
-      'var(--surface-success-secondary)',
-      'var(--surface-success-secondary-p3)',
-    ],
+    'background-color': 'var(--surface-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-success-secondary-p3)',
+    },
   },
   '.bg-error': {
-    'background-color': ['var(--surface-error)', 'var(--surface-error-p3)'],
+    'background-color': 'var(--surface-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-error-p3)',
+    },
   },
   '.bg-error-secondary': {
-    'background-color': [
-      'var(--surface-error-secondary)',
-      'var(--surface-error-secondary-p3)',
-    ],
+    'background-color': 'var(--surface-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-error-secondary-p3)',
+    },
   },
   '.bg-inverse': {
-    'background-color': ['var(--surface-inverse)', 'var(--surface-inverse-p3)'],
+    'background-color': 'var(--surface-inverse)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-inverse-p3)',
+    },
   },
   '.bg-inverse-secondary': {
-    'background-color': [
-      'var(--surface-inverse-secondary)',
-      'var(--surface-inverse-secondary-p3)',
-    ],
+    'background-color': 'var(--surface-inverse-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-inverse-secondary-p3)',
+    },
   },
   '.bg-inverse-tertiary': {
-    'background-color': [
-      'var(--surface-inverse-tertiary)',
-      'var(--surface-inverse-tertiary-p3)',
-    ],
+    'background-color': 'var(--surface-inverse-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-inverse-tertiary-p3)',
+    },
   },
   '.bg-info': {
-    'background-color': ['var(--surface-info)', 'var(--surface-info-p3)'],
+    'background-color': 'var(--surface-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-info-p3)',
+    },
   },
   '.bg-info-hover': {
-    'background-color': ['var(--surface-info-hover)', 'var(--surface-info-hover-p3)'],
+    'background-color': 'var(--surface-info-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-info-hover-p3)',
+    },
   },
   '.bg-info-secondary': {
-    'background-color': [
-      'var(--surface-info-secondary)',
-      'var(--surface-info-secondary-p3)',
-    ],
+    'background-color': 'var(--surface-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-info-secondary-p3)',
+    },
   },
   '.bg-info-secondary-hover': {
-    'background-color': [
-      'var(--surface-info-secondary-hover)',
-      'var(--surface-info-secondary-hover-p3)',
-    ],
+    'background-color': 'var(--surface-info-secondary-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--surface-info-secondary-hover-p3)',
+    },
   },
   '.bg-accent-100': {
-    'background-color': ['var(--theme-accent-100)', 'var(--theme-accent-100-p3)'],
+    'background-color': 'var(--theme-accent-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-accent-100-p3)',
+    },
   },
   '.bg-accent-200': {
-    'background-color': ['var(--theme-accent-200)', 'var(--theme-accent-200-p3)'],
+    'background-color': 'var(--theme-accent-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-accent-200-p3)',
+    },
   },
   '.bg-accent-300': {
-    'background-color': ['var(--theme-accent-300)', 'var(--theme-accent-300-p3)'],
+    'background-color': 'var(--theme-accent-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-accent-300-p3)',
+    },
   },
   '.bg-accent-400': {
-    'background-color': ['var(--theme-accent-400)', 'var(--theme-accent-400-p3)'],
+    'background-color': 'var(--theme-accent-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-accent-400-p3)',
+    },
   },
   '.bg-accent-500': {
-    'background-color': ['var(--theme-accent-500)', 'var(--theme-accent-500-p3)'],
+    'background-color': 'var(--theme-accent-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-accent-500-p3)',
+    },
   },
   '.bg-accent-600': {
-    'background-color': ['var(--theme-accent-600)', 'var(--theme-accent-600-p3)'],
+    'background-color': 'var(--theme-accent-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-accent-600-p3)',
+    },
   },
   '.bg-accent-700': {
-    'background-color': ['var(--theme-accent-700)', 'var(--theme-accent-700-p3)'],
+    'background-color': 'var(--theme-accent-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-accent-700-p3)',
+    },
   },
   '.bg-accent-800': {
-    'background-color': ['var(--theme-accent-800)', 'var(--theme-accent-800-p3)'],
+    'background-color': 'var(--theme-accent-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-accent-800-p3)',
+    },
   },
   '.bg-destructive-100': {
-    'background-color': ['var(--theme-destructive-100)', 'var(--theme-destructive-100-p3)'],
+    'background-color': 'var(--theme-destructive-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-destructive-100-p3)',
+    },
   },
   '.bg-destructive-200': {
-    'background-color': ['var(--theme-destructive-200)', 'var(--theme-destructive-200-p3)'],
+    'background-color': 'var(--theme-destructive-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-destructive-200-p3)',
+    },
   },
   '.bg-destructive-300': {
-    'background-color': ['var(--theme-destructive-300)', 'var(--theme-destructive-300-p3)'],
+    'background-color': 'var(--theme-destructive-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-destructive-300-p3)',
+    },
   },
   '.bg-destructive-400': {
-    'background-color': ['var(--theme-destructive-400)', 'var(--theme-destructive-400-p3)'],
+    'background-color': 'var(--theme-destructive-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-destructive-400-p3)',
+    },
   },
   '.bg-destructive-500': {
-    'background-color': ['var(--theme-destructive-500)', 'var(--theme-destructive-500-p3)'],
+    'background-color': 'var(--theme-destructive-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-destructive-500-p3)',
+    },
   },
   '.bg-destructive-600': {
-    'background-color': ['var(--theme-destructive-600)', 'var(--theme-destructive-600-p3)'],
+    'background-color': 'var(--theme-destructive-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-destructive-600-p3)',
+    },
   },
   '.bg-destructive-700': {
-    'background-color': ['var(--theme-destructive-700)', 'var(--theme-destructive-700-p3)'],
+    'background-color': 'var(--theme-destructive-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-destructive-700-p3)',
+    },
   },
   '.bg-destructive-800': {
-    'background-color': ['var(--theme-destructive-800)', 'var(--theme-destructive-800-p3)'],
+    'background-color': 'var(--theme-destructive-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-destructive-800-p3)',
+    },
   },
   '.bg-success-100': {
-    'background-color': ['var(--theme-success-100)', 'var(--theme-success-100-p3)'],
+    'background-color': 'var(--theme-success-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-success-100-p3)',
+    },
   },
   '.bg-success-200': {
-    'background-color': ['var(--theme-success-200)', 'var(--theme-success-200-p3)'],
+    'background-color': 'var(--theme-success-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-success-200-p3)',
+    },
   },
   '.bg-success-300': {
-    'background-color': ['var(--theme-success-300)', 'var(--theme-success-300-p3)'],
+    'background-color': 'var(--theme-success-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-success-300-p3)',
+    },
   },
   '.bg-success-400': {
-    'background-color': ['var(--theme-success-400)', 'var(--theme-success-400-p3)'],
+    'background-color': 'var(--theme-success-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-success-400-p3)',
+    },
   },
   '.bg-success-500': {
-    'background-color': ['var(--theme-success-500)', 'var(--theme-success-500-p3)'],
+    'background-color': 'var(--theme-success-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-success-500-p3)',
+    },
   },
   '.bg-success-600': {
-    'background-color': ['var(--theme-success-600)', 'var(--theme-success-600-p3)'],
+    'background-color': 'var(--theme-success-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-success-600-p3)',
+    },
   },
   '.bg-success-700': {
-    'background-color': ['var(--theme-success-700)', 'var(--theme-success-700-p3)'],
+    'background-color': 'var(--theme-success-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-success-700-p3)',
+    },
   },
   '.bg-success-800': {
-    'background-color': ['var(--theme-success-800)', 'var(--theme-success-800-p3)'],
+    'background-color': 'var(--theme-success-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-success-800-p3)',
+    },
   },
   '.bg-error-100': {
-    'background-color': ['var(--theme-error-100)', 'var(--theme-error-100-p3)'],
+    'background-color': 'var(--theme-error-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-error-100-p3)',
+    },
   },
   '.bg-error-200': {
-    'background-color': ['var(--theme-error-200)', 'var(--theme-error-200-p3)'],
+    'background-color': 'var(--theme-error-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-error-200-p3)',
+    },
   },
   '.bg-error-300': {
-    'background-color': ['var(--theme-error-300)', 'var(--theme-error-300-p3)'],
+    'background-color': 'var(--theme-error-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-error-300-p3)',
+    },
   },
   '.bg-error-400': {
-    'background-color': ['var(--theme-error-400)', 'var(--theme-error-400-p3)'],
+    'background-color': 'var(--theme-error-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-error-400-p3)',
+    },
   },
   '.bg-error-500': {
-    'background-color': ['var(--theme-error-500)', 'var(--theme-error-500-p3)'],
+    'background-color': 'var(--theme-error-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-error-500-p3)',
+    },
   },
   '.bg-error-600': {
-    'background-color': ['var(--theme-error-600)', 'var(--theme-error-600-p3)'],
+    'background-color': 'var(--theme-error-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-error-600-p3)',
+    },
   },
   '.bg-error-700': {
-    'background-color': ['var(--theme-error-700)', 'var(--theme-error-700-p3)'],
+    'background-color': 'var(--theme-error-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-error-700-p3)',
+    },
   },
   '.bg-error-800': {
-    'background-color': ['var(--theme-error-800)', 'var(--theme-error-800-p3)'],
+    'background-color': 'var(--theme-error-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-error-800-p3)',
+    },
   },
   '.bg-notice-100': {
-    'background-color': ['var(--theme-notice-100)', 'var(--theme-notice-100-p3)'],
+    'background-color': 'var(--theme-notice-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-notice-100-p3)',
+    },
   },
   '.bg-notice-200': {
-    'background-color': ['var(--theme-notice-200)', 'var(--theme-notice-200-p3)'],
+    'background-color': 'var(--theme-notice-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-notice-200-p3)',
+    },
   },
   '.bg-notice-300': {
-    'background-color': ['var(--theme-notice-300)', 'var(--theme-notice-300-p3)'],
+    'background-color': 'var(--theme-notice-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-notice-300-p3)',
+    },
   },
   '.bg-notice-400': {
-    'background-color': ['var(--theme-notice-400)', 'var(--theme-notice-400-p3)'],
+    'background-color': 'var(--theme-notice-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-notice-400-p3)',
+    },
   },
   '.bg-notice-500': {
-    'background-color': ['var(--theme-notice-500)', 'var(--theme-notice-500-p3)'],
+    'background-color': 'var(--theme-notice-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-notice-500-p3)',
+    },
   },
   '.bg-notice-600': {
-    'background-color': ['var(--theme-notice-600)', 'var(--theme-notice-600-p3)'],
+    'background-color': 'var(--theme-notice-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-notice-600-p3)',
+    },
   },
   '.bg-notice-700': {
-    'background-color': ['var(--theme-notice-700)', 'var(--theme-notice-700-p3)'],
+    'background-color': 'var(--theme-notice-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-notice-700-p3)',
+    },
   },
   '.bg-notice-800': {
-    'background-color': ['var(--theme-notice-800)', 'var(--theme-notice-800-p3)'],
+    'background-color': 'var(--theme-notice-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-notice-800-p3)',
+    },
   },
   '.bg-info-100': {
-    'background-color': ['var(--theme-info-100)', 'var(--theme-info-100-p3)'],
+    'background-color': 'var(--theme-info-100)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-info-100-p3)',
+    },
   },
   '.bg-info-200': {
-    'background-color': ['var(--theme-info-200)', 'var(--theme-info-200-p3)'],
+    'background-color': 'var(--theme-info-200)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-info-200-p3)',
+    },
   },
   '.bg-info-300': {
-    'background-color': ['var(--theme-info-300)', 'var(--theme-info-300-p3)'],
+    'background-color': 'var(--theme-info-300)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-info-300-p3)',
+    },
   },
   '.bg-info-400': {
-    'background-color': ['var(--theme-info-400)', 'var(--theme-info-400-p3)'],
+    'background-color': 'var(--theme-info-400)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-info-400-p3)',
+    },
   },
   '.bg-info-500': {
-    'background-color': ['var(--theme-info-500)', 'var(--theme-info-500-p3)'],
+    'background-color': 'var(--theme-info-500)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-info-500-p3)',
+    },
   },
   '.bg-info-600': {
-    'background-color': ['var(--theme-info-600)', 'var(--theme-info-600-p3)'],
+    'background-color': 'var(--theme-info-600)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-info-600-p3)',
+    },
   },
   '.bg-info-700': {
-    'background-color': ['var(--theme-info-700)', 'var(--theme-info-700-p3)'],
+    'background-color': 'var(--theme-info-700)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-info-700-p3)',
+    },
   },
   '.bg-info-800': {
-    'background-color': ['var(--theme-info-800)', 'var(--theme-info-800-p3)'],
+    'background-color': 'var(--theme-info-800)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'background-color': 'var(--theme-info-800-p3)',
+    },
   },
   '.border-default': {
-    'border-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    'border-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-default-p3)',
+    },
   },
   '.border-hover': {
-    'border-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    'border-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.border-secondary': {
-    'border-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    'border-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.border-tertiary': {
-    'border-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    'border-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.border-raise': {
-    'border-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    'border-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.border-surface': {
-    'border-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    'border-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.border-accent': {
-    'border-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    'border-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.border-accent-secondary': {
-    'border-color': ['var(--stroke-accent-secondary)', 'var(--stroke-accent-secondary-p3)'],
+    'border-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.border-accent-tertiary': {
-    'border-color': ['var(--stroke-accent-tertiary)', 'var(--stroke-accent-tertiary-p3)'],
+    'border-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.border-accent-quaternary': {
-    'border-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    'border-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.border-destructive': {
-    'border-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    'border-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.border-destructive-secondary': {
-    'border-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    'border-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.border-destructive-tertiary': {
-    'border-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    'border-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.border-destructive-quaternary': {
-    'border-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    'border-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.border-success': {
-    'border-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    'border-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-success-p3)',
+    },
   },
   '.border-success-secondary': {
-    'border-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    'border-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.border-success-tertiary': {
-    'border-color': ['var(--stroke-success-tertiary)', 'var(--stroke-success-tertiary-p3)'],
+    'border-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.border-success-quaternary': {
-    'border-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    'border-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.border-error': {
-    'border-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    'border-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-error-p3)',
+    },
   },
   '.border-error-secondary': {
-    'border-color': ['var(--stroke-error-secondary)', 'var(--stroke-error-secondary-p3)'],
+    'border-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.border-error-tertiary': {
-    'border-color': ['var(--stroke-error-tertiary)', 'var(--stroke-error-tertiary-p3)'],
+    'border-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.border-error-quaternary': {
-    'border-color': ['var(--stroke-error-quaternary)', 'var(--stroke-error-quaternary-p3)'],
+    'border-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.border-notice': {
-    'border-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    'border-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.border-notice-secondary': {
-    'border-color': ['var(--stroke-notice-secondary)', 'var(--stroke-notice-secondary-p3)'],
+    'border-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.border-notice-tertiary': {
-    'border-color': ['var(--stroke-notice-tertiary)', 'var(--stroke-notice-tertiary-p3)'],
+    'border-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.border-notice-quaternary': {
-    'border-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    'border-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.border-info': {
-    'border-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    'border-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-info-p3)',
+    },
   },
   '.border-info-secondary': {
-    'border-color': ['var(--stroke-info-secondary)', 'var(--stroke-info-secondary-p3)'],
+    'border-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.border-info-tertiary': {
-    'border-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
+    'border-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.border-info-quaternary': {
-    'border-color': ['var(--stroke-info-quaternary)', 'var(--stroke-info-quaternary-p3)'],
+    'border-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.border-l-default': {
-    'border-left-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    'border-left-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-default-p3)',
+    },
   },
   '.border-l-hover': {
-    'border-left-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    'border-left-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.border-l-secondary': {
-    'border-left-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    'border-left-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.border-l-tertiary': {
-    'border-left-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    'border-left-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.border-l-raise': {
-    'border-left-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    'border-left-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.border-l-surface': {
-    'border-left-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    'border-left-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.border-l-accent': {
-    'border-left-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    'border-left-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.border-l-accent-secondary': {
-    'border-left-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.border-l-accent-tertiary': {
-    'border-left-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.border-l-accent-quaternary': {
-    'border-left-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.border-l-destructive': {
-    'border-left-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    'border-left-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.border-l-destructive-secondary': {
-    'border-left-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.border-l-destructive-tertiary': {
-    'border-left-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.border-l-destructive-quaternary': {
-    'border-left-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.border-l-success': {
-    'border-left-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    'border-left-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-success-p3)',
+    },
   },
   '.border-l-success-secondary': {
-    'border-left-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.border-l-success-tertiary': {
-    'border-left-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.border-l-success-quaternary': {
-    'border-left-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.border-l-error': {
-    'border-left-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    'border-left-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-error-p3)',
+    },
   },
   '.border-l-error-secondary': {
-    'border-left-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.border-l-error-tertiary': {
-    'border-left-color': [
-      'var(--stroke-error-tertiary)',
-      'var(--stroke-error-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.border-l-error-quaternary': {
-    'border-left-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.border-l-notice': {
-    'border-left-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    'border-left-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.border-l-notice-secondary': {
-    'border-left-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.border-l-notice-tertiary': {
-    'border-left-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.border-l-notice-quaternary': {
-    'border-left-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.border-l-info': {
-    'border-left-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    'border-left-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-info-p3)',
+    },
   },
   '.border-l-info-secondary': {
-    'border-left-color': [
-      'var(--stroke-info-secondary)',
-      'var(--stroke-info-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.border-l-info-tertiary': {
-    'border-left-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
+    'border-left-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.border-l-info-quaternary': {
-    'border-left-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.border-r-default': {
-    'border-right-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    'border-right-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-default-p3)',
+    },
   },
   '.border-r-hover': {
-    'border-right-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    'border-right-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.border-r-secondary': {
-    'border-right-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    'border-right-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.border-r-tertiary': {
-    'border-right-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    'border-right-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.border-r-raise': {
-    'border-right-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    'border-right-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.border-r-surface': {
-    'border-right-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    'border-right-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.border-r-accent': {
-    'border-right-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    'border-right-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.border-r-accent-secondary': {
-    'border-right-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.border-r-accent-tertiary': {
-    'border-right-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.border-r-accent-quaternary': {
-    'border-right-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.border-r-destructive': {
-    'border-right-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    'border-right-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.border-r-destructive-secondary': {
-    'border-right-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.border-r-destructive-tertiary': {
-    'border-right-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.border-r-destructive-quaternary': {
-    'border-right-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.border-r-success': {
-    'border-right-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    'border-right-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-success-p3)',
+    },
   },
   '.border-r-success-secondary': {
-    'border-right-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.border-r-success-tertiary': {
-    'border-right-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.border-r-success-quaternary': {
-    'border-right-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.border-r-error': {
-    'border-right-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    'border-right-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-error-p3)',
+    },
   },
   '.border-r-error-secondary': {
-    'border-right-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.border-r-error-tertiary': {
-    'border-right-color': [
-      'var(--stroke-error-tertiary)',
-      'var(--stroke-error-tertiary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.border-r-error-quaternary': {
-    'border-right-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.border-r-notice': {
-    'border-right-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    'border-right-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.border-r-notice-secondary': {
-    'border-right-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.border-r-notice-tertiary': {
-    'border-right-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.border-r-notice-quaternary': {
-    'border-right-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.border-r-info': {
-    'border-right-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    'border-right-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-info-p3)',
+    },
   },
   '.border-r-info-secondary': {
-    'border-right-color': [
-      'var(--stroke-info-secondary)',
-      'var(--stroke-info-secondary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.border-r-info-tertiary': {
-    'border-right-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
+    'border-right-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.border-r-info-quaternary': {
-    'border-right-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
+    'border-right-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-right-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.border-t-default': {
-    'border-top-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    'border-top-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-default-p3)',
+    },
   },
   '.border-t-hover': {
-    'border-top-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    'border-top-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.border-t-secondary': {
-    'border-top-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    'border-top-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.border-t-tertiary': {
-    'border-top-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    'border-top-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.border-t-raise': {
-    'border-top-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    'border-top-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.border-t-surface': {
-    'border-top-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    'border-top-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.border-t-accent': {
-    'border-top-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    'border-top-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.border-t-accent-secondary': {
-    'border-top-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.border-t-accent-tertiary': {
-    'border-top-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.border-t-accent-quaternary': {
-    'border-top-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.border-t-destructive': {
-    'border-top-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    'border-top-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.border-t-destructive-secondary': {
-    'border-top-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.border-t-destructive-tertiary': {
-    'border-top-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.border-t-destructive-quaternary': {
-    'border-top-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.border-t-success': {
-    'border-top-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    'border-top-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-success-p3)',
+    },
   },
   '.border-t-success-secondary': {
-    'border-top-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.border-t-success-tertiary': {
-    'border-top-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.border-t-success-quaternary': {
-    'border-top-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.border-t-error': {
-    'border-top-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    'border-top-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-error-p3)',
+    },
   },
   '.border-t-error-secondary': {
-    'border-top-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.border-t-error-tertiary': {
-    'border-top-color': ['var(--stroke-error-tertiary)', 'var(--stroke-error-tertiary-p3)'],
+    'border-top-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.border-t-error-quaternary': {
-    'border-top-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.border-t-notice': {
-    'border-top-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    'border-top-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.border-t-notice-secondary': {
-    'border-top-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.border-t-notice-tertiary': {
-    'border-top-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.border-t-notice-quaternary': {
-    'border-top-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.border-t-info': {
-    'border-top-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    'border-top-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-info-p3)',
+    },
   },
   '.border-t-info-secondary': {
-    'border-top-color': ['var(--stroke-info-secondary)', 'var(--stroke-info-secondary-p3)'],
+    'border-top-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.border-t-info-tertiary': {
-    'border-top-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
+    'border-top-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.border-t-info-quaternary': {
-    'border-top-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.border-b-default': {
-    'border-bottom-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    'border-bottom-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-default-p3)',
+    },
   },
   '.border-b-hover': {
-    'border-bottom-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    'border-bottom-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.border-b-secondary': {
-    'border-bottom-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    'border-bottom-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.border-b-tertiary': {
-    'border-bottom-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    'border-bottom-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.border-b-raise': {
-    'border-bottom-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    'border-bottom-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.border-b-surface': {
-    'border-bottom-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    'border-bottom-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.border-b-accent': {
-    'border-bottom-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    'border-bottom-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.border-b-accent-secondary': {
-    'border-bottom-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.border-b-accent-tertiary': {
-    'border-bottom-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.border-b-accent-quaternary': {
-    'border-bottom-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.border-b-destructive': {
-    'border-bottom-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    'border-bottom-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.border-b-destructive-secondary': {
-    'border-bottom-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.border-b-destructive-tertiary': {
-    'border-bottom-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.border-b-destructive-quaternary': {
-    'border-bottom-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.border-b-success': {
-    'border-bottom-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    'border-bottom-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-success-p3)',
+    },
   },
   '.border-b-success-secondary': {
-    'border-bottom-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.border-b-success-tertiary': {
-    'border-bottom-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.border-b-success-quaternary': {
-    'border-bottom-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.border-b-error': {
-    'border-bottom-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    'border-bottom-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-error-p3)',
+    },
   },
   '.border-b-error-secondary': {
-    'border-bottom-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.border-b-error-tertiary': {
-    'border-bottom-color': [
-      'var(--stroke-error-tertiary)',
-      'var(--stroke-error-tertiary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.border-b-error-quaternary': {
-    'border-bottom-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.border-b-notice': {
-    'border-bottom-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    'border-bottom-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.border-b-notice-secondary': {
-    'border-bottom-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.border-b-notice-tertiary': {
-    'border-bottom-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.border-b-notice-quaternary': {
-    'border-bottom-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.border-b-info': {
-    'border-bottom-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    'border-bottom-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-info-p3)',
+    },
   },
   '.border-b-info-secondary': {
-    'border-bottom-color': [
-      'var(--stroke-info-secondary)',
-      'var(--stroke-info-secondary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.border-b-info-tertiary': {
-    'border-bottom-color': [
-      'var(--stroke-info-tertiary)',
-      'var(--stroke-info-tertiary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.border-b-info-quaternary': {
-    'border-bottom-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
+    'border-bottom-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-bottom-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.border-x-default': {
-    'border-left-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
-    'border-right-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    'border-left-color': 'var(--stroke-default)',
+    'border-right-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-default-p3)',
+      'border-right-color': 'var(--stroke-default-p3)',
+    },
   },
   '.border-x-hover': {
-    'border-left-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
-    'border-right-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    'border-left-color': 'var(--stroke-hover)',
+    'border-right-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-hover-p3)',
+      'border-right-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.border-x-secondary': {
-    'border-left-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
-    'border-right-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    'border-left-color': 'var(--stroke-secondary)',
+    'border-right-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-secondary-p3)',
+      'border-right-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.border-x-tertiary': {
-    'border-left-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
-    'border-right-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    'border-left-color': 'var(--stroke-tertiary)',
+    'border-right-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-tertiary-p3)',
+      'border-right-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.border-x-raise': {
-    'border-left-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
-    'border-right-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    'border-left-color': 'var(--stroke-raise)',
+    'border-right-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-raise-p3)',
+      'border-right-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.border-x-surface': {
-    'border-left-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
-    'border-right-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    'border-left-color': 'var(--stroke-surface)',
+    'border-right-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-surface-p3)',
+      'border-right-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.border-x-accent': {
-    'border-left-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
-    'border-right-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    'border-left-color': 'var(--stroke-accent)',
+    'border-right-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-accent-p3)',
+      'border-right-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.border-x-accent-secondary': {
-    'border-left-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-accent-secondary)',
+    'border-right-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-accent-secondary-p3)',
+      'border-right-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.border-x-accent-tertiary': {
-    'border-left-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-accent-tertiary)',
+    'border-right-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-accent-tertiary-p3)',
+      'border-right-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.border-x-accent-quaternary': {
-    'border-left-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-accent-quaternary)',
+    'border-right-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-accent-quaternary-p3)',
+      'border-right-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.border-x-destructive': {
-    'border-left-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
-    'border-right-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    'border-left-color': 'var(--stroke-destructive)',
+    'border-right-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-destructive-p3)',
+      'border-right-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.border-x-destructive-secondary': {
-    'border-left-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-destructive-secondary)',
+    'border-right-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-destructive-secondary-p3)',
+      'border-right-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.border-x-destructive-tertiary': {
-    'border-left-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-destructive-tertiary)',
+    'border-right-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-destructive-tertiary-p3)',
+      'border-right-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.border-x-destructive-quaternary': {
-    'border-left-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-destructive-quaternary)',
+    'border-right-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-destructive-quaternary-p3)',
+      'border-right-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.border-x-success': {
-    'border-left-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
-    'border-right-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    'border-left-color': 'var(--stroke-success)',
+    'border-right-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-success-p3)',
+      'border-right-color': 'var(--stroke-success-p3)',
+    },
   },
   '.border-x-success-secondary': {
-    'border-left-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-success-secondary)',
+    'border-right-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-success-secondary-p3)',
+      'border-right-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.border-x-success-tertiary': {
-    'border-left-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-success-tertiary)',
+    'border-right-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-success-tertiary-p3)',
+      'border-right-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.border-x-success-quaternary': {
-    'border-left-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-success-quaternary)',
+    'border-right-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-success-quaternary-p3)',
+      'border-right-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.border-x-error': {
-    'border-left-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
-    'border-right-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    'border-left-color': 'var(--stroke-error)',
+    'border-right-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-error-p3)',
+      'border-right-color': 'var(--stroke-error-p3)',
+    },
   },
   '.border-x-error-secondary': {
-    'border-left-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-error-secondary)',
+    'border-right-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-error-secondary-p3)',
+      'border-right-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.border-x-error-tertiary': {
-    'border-left-color': [
-      'var(--stroke-error-tertiary)',
-      'var(--stroke-error-tertiary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-error-tertiary)',
-      'var(--stroke-error-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-error-tertiary)',
+    'border-right-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-error-tertiary-p3)',
+      'border-right-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.border-x-error-quaternary': {
-    'border-left-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-error-quaternary)',
+    'border-right-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-error-quaternary-p3)',
+      'border-right-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.border-x-notice': {
-    'border-left-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
-    'border-right-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    'border-left-color': 'var(--stroke-notice)',
+    'border-right-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-notice-p3)',
+      'border-right-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.border-x-notice-secondary': {
-    'border-left-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-notice-secondary)',
+    'border-right-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-notice-secondary-p3)',
+      'border-right-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.border-x-notice-tertiary': {
-    'border-left-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-notice-tertiary)',
+    'border-right-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-notice-tertiary-p3)',
+      'border-right-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.border-x-notice-quaternary': {
-    'border-left-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-notice-quaternary)',
+    'border-right-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-notice-quaternary-p3)',
+      'border-right-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.border-x-info': {
-    'border-left-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
-    'border-right-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    'border-left-color': 'var(--stroke-info)',
+    'border-right-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-info-p3)',
+      'border-right-color': 'var(--stroke-info-p3)',
+    },
   },
   '.border-x-info-secondary': {
-    'border-left-color': [
-      'var(--stroke-info-secondary)',
-      'var(--stroke-info-secondary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-info-secondary)',
-      'var(--stroke-info-secondary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-info-secondary)',
+    'border-right-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-info-secondary-p3)',
+      'border-right-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.border-x-info-tertiary': {
-    'border-left-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
-    'border-right-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
+    'border-left-color': 'var(--stroke-info-tertiary)',
+    'border-right-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-info-tertiary-p3)',
+      'border-right-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.border-x-info-quaternary': {
-    'border-left-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
-    'border-right-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
+    'border-left-color': 'var(--stroke-info-quaternary)',
+    'border-right-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-left-color': 'var(--stroke-info-quaternary-p3)',
+      'border-right-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.border-y-default': {
-    'border-top-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
-    'border-bottom-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    'border-top-color': 'var(--stroke-default)',
+    'border-bottom-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-default-p3)',
+      'border-bottom-color': 'var(--stroke-default-p3)',
+    },
   },
   '.border-y-hover': {
-    'border-top-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
-    'border-bottom-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    'border-top-color': 'var(--stroke-hover)',
+    'border-bottom-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-hover-p3)',
+      'border-bottom-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.border-y-secondary': {
-    'border-top-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
-    'border-bottom-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    'border-top-color': 'var(--stroke-secondary)',
+    'border-bottom-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-secondary-p3)',
+      'border-bottom-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.border-y-tertiary': {
-    'border-top-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
-    'border-bottom-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    'border-top-color': 'var(--stroke-tertiary)',
+    'border-bottom-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-tertiary-p3)',
+      'border-bottom-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.border-y-raise': {
-    'border-top-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
-    'border-bottom-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    'border-top-color': 'var(--stroke-raise)',
+    'border-bottom-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-raise-p3)',
+      'border-bottom-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.border-y-surface': {
-    'border-top-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
-    'border-bottom-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    'border-top-color': 'var(--stroke-surface)',
+    'border-bottom-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-surface-p3)',
+      'border-bottom-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.border-y-accent': {
-    'border-top-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
-    'border-bottom-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    'border-top-color': 'var(--stroke-accent)',
+    'border-bottom-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-accent-p3)',
+      'border-bottom-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.border-y-accent-secondary': {
-    'border-top-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-accent-secondary)',
+    'border-bottom-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-accent-secondary-p3)',
+      'border-bottom-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.border-y-accent-tertiary': {
-    'border-top-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-accent-tertiary)',
+    'border-bottom-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-accent-tertiary-p3)',
+      'border-bottom-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.border-y-accent-quaternary': {
-    'border-top-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-accent-quaternary)',
+    'border-bottom-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-accent-quaternary-p3)',
+      'border-bottom-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.border-y-destructive': {
-    'border-top-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
-    'border-bottom-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    'border-top-color': 'var(--stroke-destructive)',
+    'border-bottom-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-destructive-p3)',
+      'border-bottom-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.border-y-destructive-secondary': {
-    'border-top-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-destructive-secondary)',
+    'border-bottom-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-destructive-secondary-p3)',
+      'border-bottom-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.border-y-destructive-tertiary': {
-    'border-top-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-destructive-tertiary)',
+    'border-bottom-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-destructive-tertiary-p3)',
+      'border-bottom-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.border-y-destructive-quaternary': {
-    'border-top-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-destructive-quaternary)',
+    'border-bottom-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-destructive-quaternary-p3)',
+      'border-bottom-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.border-y-success': {
-    'border-top-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
-    'border-bottom-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    'border-top-color': 'var(--stroke-success)',
+    'border-bottom-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-success-p3)',
+      'border-bottom-color': 'var(--stroke-success-p3)',
+    },
   },
   '.border-y-success-secondary': {
-    'border-top-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-success-secondary)',
+    'border-bottom-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-success-secondary-p3)',
+      'border-bottom-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.border-y-success-tertiary': {
-    'border-top-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-success-tertiary)',
+    'border-bottom-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-success-tertiary-p3)',
+      'border-bottom-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.border-y-success-quaternary': {
-    'border-top-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-success-quaternary)',
+    'border-bottom-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-success-quaternary-p3)',
+      'border-bottom-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.border-y-error': {
-    'border-top-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
-    'border-bottom-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    'border-top-color': 'var(--stroke-error)',
+    'border-bottom-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-error-p3)',
+      'border-bottom-color': 'var(--stroke-error-p3)',
+    },
   },
   '.border-y-error-secondary': {
-    'border-top-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-error-secondary)',
+    'border-bottom-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-error-secondary-p3)',
+      'border-bottom-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.border-y-error-tertiary': {
-    'border-top-color': ['var(--stroke-error-tertiary)', 'var(--stroke-error-tertiary-p3)'],
-    'border-bottom-color': [
-      'var(--stroke-error-tertiary)',
-      'var(--stroke-error-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-error-tertiary)',
+    'border-bottom-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-error-tertiary-p3)',
+      'border-bottom-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.border-y-error-quaternary': {
-    'border-top-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-error-quaternary)',
+    'border-bottom-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-error-quaternary-p3)',
+      'border-bottom-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.border-y-notice': {
-    'border-top-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
-    'border-bottom-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    'border-top-color': 'var(--stroke-notice)',
+    'border-bottom-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-notice-p3)',
+      'border-bottom-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.border-y-notice-secondary': {
-    'border-top-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-notice-secondary)',
+    'border-bottom-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-notice-secondary-p3)',
+      'border-bottom-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.border-y-notice-tertiary': {
-    'border-top-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-notice-tertiary)',
+    'border-bottom-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-notice-tertiary-p3)',
+      'border-bottom-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.border-y-notice-quaternary': {
-    'border-top-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-notice-quaternary)',
+    'border-bottom-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-notice-quaternary-p3)',
+      'border-bottom-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.border-y-info': {
-    'border-top-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
-    'border-bottom-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    'border-top-color': 'var(--stroke-info)',
+    'border-bottom-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-info-p3)',
+      'border-bottom-color': 'var(--stroke-info-p3)',
+    },
   },
   '.border-y-info-secondary': {
-    'border-top-color': ['var(--stroke-info-secondary)', 'var(--stroke-info-secondary-p3)'],
-    'border-bottom-color': [
-      'var(--stroke-info-secondary)',
-      'var(--stroke-info-secondary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-info-secondary)',
+    'border-bottom-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-info-secondary-p3)',
+      'border-bottom-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.border-y-info-tertiary': {
-    'border-top-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
-    'border-bottom-color': [
-      'var(--stroke-info-tertiary)',
-      'var(--stroke-info-tertiary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-info-tertiary)',
+    'border-bottom-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-info-tertiary-p3)',
+      'border-bottom-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.border-y-info-quaternary': {
-    'border-top-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
-    'border-bottom-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
+    'border-top-color': 'var(--stroke-info-quaternary)',
+    'border-bottom-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'border-top-color': 'var(--stroke-info-quaternary-p3)',
+      'border-bottom-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.ring-default': {
-    '--tw-ring-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    '--tw-ring-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-default-p3)',
+    },
   },
   '.ring-hover': {
-    '--tw-ring-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    '--tw-ring-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.ring-secondary': {
-    '--tw-ring-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    '--tw-ring-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.ring-tertiary': {
-    '--tw-ring-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    '--tw-ring-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.ring-raise': {
-    '--tw-ring-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    '--tw-ring-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.ring-surface': {
-    '--tw-ring-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    '--tw-ring-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.ring-accent': {
-    '--tw-ring-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    '--tw-ring-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.ring-accent-secondary': {
-    '--tw-ring-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.ring-accent-tertiary': {
-    '--tw-ring-color': [
-      'var(--stroke-accent-tertiary)',
-      'var(--stroke-accent-tertiary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.ring-accent-quaternary': {
-    '--tw-ring-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.ring-destructive': {
-    '--tw-ring-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    '--tw-ring-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.ring-destructive-secondary': {
-    '--tw-ring-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.ring-destructive-tertiary': {
-    '--tw-ring-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.ring-destructive-quaternary': {
-    '--tw-ring-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.ring-success': {
-    '--tw-ring-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    '--tw-ring-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-success-p3)',
+    },
   },
   '.ring-success-secondary': {
-    '--tw-ring-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.ring-success-tertiary': {
-    '--tw-ring-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.ring-success-quaternary': {
-    '--tw-ring-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.ring-error': {
-    '--tw-ring-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    '--tw-ring-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-error-p3)',
+    },
   },
   '.ring-error-secondary': {
-    '--tw-ring-color': [
-      'var(--stroke-error-secondary)',
-      'var(--stroke-error-secondary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.ring-error-tertiary': {
-    '--tw-ring-color': ['var(--stroke-error-tertiary)', 'var(--stroke-error-tertiary-p3)'],
+    '--tw-ring-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.ring-error-quaternary': {
-    '--tw-ring-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.ring-notice': {
-    '--tw-ring-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    '--tw-ring-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.ring-notice-secondary': {
-    '--tw-ring-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.ring-notice-tertiary': {
-    '--tw-ring-color': [
-      'var(--stroke-notice-tertiary)',
-      'var(--stroke-notice-tertiary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.ring-notice-quaternary': {
-    '--tw-ring-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.ring-info': {
-    '--tw-ring-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    '--tw-ring-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-info-p3)',
+    },
   },
   '.ring-info-secondary': {
-    '--tw-ring-color': ['var(--stroke-info-secondary)', 'var(--stroke-info-secondary-p3)'],
+    '--tw-ring-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.ring-info-tertiary': {
-    '--tw-ring-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
+    '--tw-ring-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.ring-info-quaternary': {
-    '--tw-ring-color': [
-      'var(--stroke-info-quaternary)',
-      'var(--stroke-info-quaternary-p3)',
-    ],
+    '--tw-ring-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      '--tw-ring-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.outline-default': {
-    'outline-color': ['var(--stroke-default)', 'var(--stroke-default-p3)'],
+    'outline-color': 'var(--stroke-default)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-default-p3)',
+    },
   },
   '.outline-hover': {
-    'outline-color': ['var(--stroke-hover)', 'var(--stroke-hover-p3)'],
+    'outline-color': 'var(--stroke-hover)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-hover-p3)',
+    },
   },
   '.outline-secondary': {
-    'outline-color': ['var(--stroke-secondary)', 'var(--stroke-secondary-p3)'],
+    'outline-color': 'var(--stroke-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-secondary-p3)',
+    },
   },
   '.outline-tertiary': {
-    'outline-color': ['var(--stroke-tertiary)', 'var(--stroke-tertiary-p3)'],
+    'outline-color': 'var(--stroke-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-tertiary-p3)',
+    },
   },
   '.outline-raise': {
-    'outline-color': ['var(--stroke-raise)', 'var(--stroke-raise-p3)'],
+    'outline-color': 'var(--stroke-raise)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-raise-p3)',
+    },
   },
   /* Matches the default surface color */
   '.outline-surface': {
-    'outline-color': ['var(--stroke-surface)', 'var(--stroke-surface-p3)'],
+    'outline-color': 'var(--stroke-surface)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-surface-p3)',
+    },
   },
   '.outline-accent': {
-    'outline-color': ['var(--stroke-accent)', 'var(--stroke-accent-p3)'],
+    'outline-color': 'var(--stroke-accent)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-accent-p3)',
+    },
   },
   '.outline-accent-secondary': {
-    'outline-color': [
-      'var(--stroke-accent-secondary)',
-      'var(--stroke-accent-secondary-p3)',
-    ],
+    'outline-color': 'var(--stroke-accent-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-accent-secondary-p3)',
+    },
   },
   '.outline-accent-tertiary': {
-    'outline-color': ['var(--stroke-accent-tertiary)', 'var(--stroke-accent-tertiary-p3)'],
+    'outline-color': 'var(--stroke-accent-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-accent-tertiary-p3)',
+    },
   },
   '.outline-accent-quaternary': {
-    'outline-color': [
-      'var(--stroke-accent-quaternary)',
-      'var(--stroke-accent-quaternary-p3)',
-    ],
+    'outline-color': 'var(--stroke-accent-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-accent-quaternary-p3)',
+    },
   },
   '.outline-destructive': {
-    'outline-color': ['var(--stroke-destructive)', 'var(--stroke-destructive-p3)'],
+    'outline-color': 'var(--stroke-destructive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-destructive-p3)',
+    },
   },
   '.outline-destructive-secondary': {
-    'outline-color': [
-      'var(--stroke-destructive-secondary)',
-      'var(--stroke-destructive-secondary-p3)',
-    ],
+    'outline-color': 'var(--stroke-destructive-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-destructive-secondary-p3)',
+    },
   },
   '.outline-destructive-tertiary': {
-    'outline-color': [
-      'var(--stroke-destructive-tertiary)',
-      'var(--stroke-destructive-tertiary-p3)',
-    ],
+    'outline-color': 'var(--stroke-destructive-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-destructive-tertiary-p3)',
+    },
   },
   '.outline-destructive-quaternary': {
-    'outline-color': [
-      'var(--stroke-destructive-quaternary)',
-      'var(--stroke-destructive-quaternary-p3)',
-    ],
+    'outline-color': 'var(--stroke-destructive-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-destructive-quaternary-p3)',
+    },
   },
   '.outline-success': {
-    'outline-color': ['var(--stroke-success)', 'var(--stroke-success-p3)'],
+    'outline-color': 'var(--stroke-success)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-success-p3)',
+    },
   },
   '.outline-success-secondary': {
-    'outline-color': [
-      'var(--stroke-success-secondary)',
-      'var(--stroke-success-secondary-p3)',
-    ],
+    'outline-color': 'var(--stroke-success-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-success-secondary-p3)',
+    },
   },
   '.outline-success-tertiary': {
-    'outline-color': [
-      'var(--stroke-success-tertiary)',
-      'var(--stroke-success-tertiary-p3)',
-    ],
+    'outline-color': 'var(--stroke-success-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-success-tertiary-p3)',
+    },
   },
   '.outline-success-quaternary': {
-    'outline-color': [
-      'var(--stroke-success-quaternary)',
-      'var(--stroke-success-quaternary-p3)',
-    ],
+    'outline-color': 'var(--stroke-success-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-success-quaternary-p3)',
+    },
   },
   '.outline-error': {
-    'outline-color': ['var(--stroke-error)', 'var(--stroke-error-p3)'],
+    'outline-color': 'var(--stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-error-p3)',
+    },
   },
   '.outline-error-secondary': {
-    'outline-color': ['var(--stroke-error-secondary)', 'var(--stroke-error-secondary-p3)'],
+    'outline-color': 'var(--stroke-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-error-secondary-p3)',
+    },
   },
   '.outline-error-tertiary': {
-    'outline-color': ['var(--stroke-error-tertiary)', 'var(--stroke-error-tertiary-p3)'],
+    'outline-color': 'var(--stroke-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-error-tertiary-p3)',
+    },
   },
   '.outline-error-quaternary': {
-    'outline-color': [
-      'var(--stroke-error-quaternary)',
-      'var(--stroke-error-quaternary-p3)',
-    ],
+    'outline-color': 'var(--stroke-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-error-quaternary-p3)',
+    },
   },
   '.outline-notice': {
-    'outline-color': ['var(--stroke-notice)', 'var(--stroke-notice-p3)'],
+    'outline-color': 'var(--stroke-notice)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-notice-p3)',
+    },
   },
   '.outline-notice-secondary': {
-    'outline-color': [
-      'var(--stroke-notice-secondary)',
-      'var(--stroke-notice-secondary-p3)',
-    ],
+    'outline-color': 'var(--stroke-notice-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-notice-secondary-p3)',
+    },
   },
   '.outline-notice-tertiary': {
-    'outline-color': ['var(--stroke-notice-tertiary)', 'var(--stroke-notice-tertiary-p3)'],
+    'outline-color': 'var(--stroke-notice-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-notice-tertiary-p3)',
+    },
   },
   '.outline-notice-quaternary': {
-    'outline-color': [
-      'var(--stroke-notice-quaternary)',
-      'var(--stroke-notice-quaternary-p3)',
-    ],
+    'outline-color': 'var(--stroke-notice-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-notice-quaternary-p3)',
+    },
   },
   '.outline-info': {
-    'outline-color': ['var(--stroke-info)', 'var(--stroke-info-p3)'],
+    'outline-color': 'var(--stroke-info)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-info-p3)',
+    },
   },
   '.outline-info-secondary': {
-    'outline-color': ['var(--stroke-info-secondary)', 'var(--stroke-info-secondary-p3)'],
+    'outline-color': 'var(--stroke-info-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-info-secondary-p3)',
+    },
   },
   '.outline-info-tertiary': {
-    'outline-color': ['var(--stroke-info-tertiary)', 'var(--stroke-info-tertiary-p3)'],
+    'outline-color': 'var(--stroke-info-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-info-tertiary-p3)',
+    },
   },
   '.outline-info-quaternary': {
-    'outline-color': ['var(--stroke-info-quaternary)', 'var(--stroke-info-quaternary-p3)'],
+    'outline-color': 'var(--stroke-info-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      'outline-color': 'var(--stroke-info-quaternary-p3)',
+    },
   },
   '.chart-fill-area-primary': {
-    fill: ['var(--chart-fill-area-primary)', 'var(--chart-fill-area-primary-p3)'],
+    fill: 'var(--chart-fill-area-primary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-area-primary-p3)',
+    },
   },
   '.chart-fill-area-secondary': {
-    fill: ['var(--chart-fill-area-secondary)', 'var(--chart-fill-area-secondary-p3)'],
+    fill: 'var(--chart-fill-area-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-area-secondary-p3)',
+    },
   },
   '.chart-fill-area-tertiary': {
-    fill: ['var(--chart-fill-area-tertiary)', 'var(--chart-fill-area-tertiary-p3)'],
+    fill: 'var(--chart-fill-area-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-area-tertiary-p3)',
+    },
   },
   '.chart-fill-area-quaternary': {
-    fill: ['var(--chart-fill-area-quaternary)', 'var(--chart-fill-area-quaternary-p3)'],
+    fill: 'var(--chart-fill-area-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-area-quaternary-p3)',
+    },
   },
   '.chart-fill-item-primary': {
-    fill: ['var(--chart-fill-item-primary)', 'var(--chart-fill-item-primary-p3)'],
+    fill: 'var(--chart-fill-item-primary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-item-primary-p3)',
+    },
   },
   '.chart-fill-item-secondary': {
-    fill: ['var(--chart-fill-item-secondary)', 'var(--chart-fill-item-secondary-p3)'],
+    fill: 'var(--chart-fill-item-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-item-secondary-p3)',
+    },
   },
   '.chart-fill-item-tertiary': {
-    fill: ['var(--chart-fill-item-tertiary)', 'var(--chart-fill-item-tertiary-p3)'],
+    fill: 'var(--chart-fill-item-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-item-tertiary-p3)',
+    },
   },
   '.chart-fill-item-quaternary': {
-    fill: ['var(--chart-fill-item-quaternary)', 'var(--chart-fill-item-quaternary-p3)'],
+    fill: 'var(--chart-fill-item-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-item-quaternary-p3)',
+    },
   },
   '.chart-fill-error-primary': {
-    fill: ['var(--chart-fill-error-primary)', 'var(--chart-fill-error-primary-p3)'],
+    fill: 'var(--chart-fill-error-primary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-error-primary-p3)',
+    },
   },
   '.chart-fill-error-secondary': {
-    fill: ['var(--chart-fill-error-secondary)', 'var(--chart-fill-error-secondary-p3)'],
+    fill: 'var(--chart-fill-error-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-error-secondary-p3)',
+    },
   },
   '.chart-fill-error-tertiary': {
-    fill: ['var(--chart-fill-error-tertiary)', 'var(--chart-fill-error-tertiary-p3)'],
+    fill: 'var(--chart-fill-error-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-error-tertiary-p3)',
+    },
   },
   '.chart-fill-error-quaternary': {
-    fill: ['var(--chart-fill-error-quaternary)', 'var(--chart-fill-error-quaternary-p3)'],
+    fill: 'var(--chart-fill-error-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-error-quaternary-p3)',
+    },
   },
   '.chart-fill-inactive': {
-    fill: ['var(--chart-fill-inactive)', 'var(--chart-fill-inactive-p3)'],
+    fill: 'var(--chart-fill-inactive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      fill: 'var(--chart-fill-inactive-p3)',
+    },
   },
   '.chart-stroke-line': {
-    stroke: ['var(--chart-stroke-line)', 'var(--chart-stroke-line-p3)'],
+    stroke: 'var(--chart-stroke-line)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      stroke: 'var(--chart-stroke-line-p3)',
+    },
   },
   '.chart-stroke-line-secondary': {
-    stroke: ['var(--chart-stroke-line-secondary)', 'var(--chart-stroke-line-secondary-p3)'],
+    stroke: 'var(--chart-stroke-line-secondary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      stroke: 'var(--chart-stroke-line-secondary-p3)',
+    },
   },
   '.chart-stroke-line-tertiary': {
-    stroke: ['var(--chart-stroke-line-tertiary)', 'var(--chart-stroke-line-tertiary-p3)'],
+    stroke: 'var(--chart-stroke-line-tertiary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      stroke: 'var(--chart-stroke-line-tertiary-p3)',
+    },
   },
   '.chart-stroke-line-quaternary': {
-    stroke: [
-      'var(--chart-stroke-line-quaternary)',
-      'var(--chart-stroke-line-quaternary-p3)',
-    ],
+    stroke: 'var(--chart-stroke-line-quaternary)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      stroke: 'var(--chart-stroke-line-quaternary-p3)',
+    },
   },
   '.chart-stroke-y-axis': {
-    stroke: ['var(--chart-stroke-y-axis)', 'var(--chart-stroke-y-axis-p3)'],
+    stroke: 'var(--chart-stroke-y-axis)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      stroke: 'var(--chart-stroke-y-axis-p3)',
+    },
   },
   /* Used as a stroke in conjuction with a fill. For discrete shapes e.g. bar charts; pie charts; tree maps. */
   '.chart-stroke-item': {
-    stroke: ['var(--chart-stroke-item)', 'var(--chart-stroke-item-p3)'],
+    stroke: 'var(--chart-stroke-item)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      stroke: 'var(--chart-stroke-item-p3)',
+    },
   },
   '.chart-stroke-item-inactive': {
-    stroke: ['var(--chart-stroke-item-inactive)', 'var(--chart-stroke-item-inactive-p3)'],
+    stroke: 'var(--chart-stroke-item-inactive)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      stroke: 'var(--chart-stroke-item-inactive-p3)',
+    },
   },
   '.chart-stroke-error': {
-    stroke: ['var(--chart-stroke-error)', 'var(--chart-stroke-error-p3)'],
+    stroke: 'var(--chart-stroke-error)',
+    '@supports (color: color(display-p3 1 1 1))': {
+      stroke: 'var(--chart-stroke-error-p3)',
+    },
   },
 }
 


### PR DESCRIPTION
Colours broken in older chrome versions on windows (not tested elsewhere), not falling back properly. Going to try reimplementing '@supports'.

<img width="702" alt="image" src="https://github.com/oxidecomputer/design-system/assets/4020798/2a1abe03-dd32-47f3-b296-808f4414ce1b">
