### PR TITLE
[AsciiDoc] Use `object-contain` on image blocks

### DIFF
--- a/components/dist/asciidoc.css
+++ b/components/dist/asciidoc.css
@@ -40,9 +40,13 @@
     @apply normal-case;
   }
 
-  .asciidoc-body img {
-    @apply mx-auto h-auto w-auto w-full rounded-lg border border-tertiary;
+  .asciidoc-body .imageblock img {
+    @apply mx-auto h-auto w-auto w-full rounded-lg border border-tertiary object-contain;
     max-height: max(500px, 75vh);
+  }
+
+  .asciidoc-body span img {
+    @apply inline;
   }
 
   .asciidoc-body img.transparent-dark {
@@ -702,11 +706,6 @@
     pre {
       hyphens: none;
       white-space: pre-wrap;
-    }
-
-    .asciidoc-body img {
-      max-height: max(400px, 25vh);
-      margin-left: 0;
     }
 
     h1 {

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -40,9 +40,13 @@
     @apply normal-case;
   }
 
-  .asciidoc-body img {
-    @apply mx-auto h-auto w-auto w-full rounded-lg border border-tertiary;
+  .asciidoc-body .imageblock img {
+    @apply mx-auto h-auto w-auto w-full rounded-lg border border-tertiary object-contain;
     max-height: max(500px, 75vh);
+  }
+
+  .asciidoc-body span img {
+    @apply inline;
   }
 
   .asciidoc-body img.transparent-dark {
@@ -702,11 +706,6 @@
     pre {
       hyphens: none;
       white-space: pre-wrap;
-    }
-
-    .asciidoc-body img {
-      max-height: max(400px, 25vh);
-      margin-left: 0;
     }
 
     h1 {


### PR DESCRIPTION
Fixes #58 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.11--canary.66.0131a65.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @oxide/design-system@1.2.11--canary.66.0131a65.0
  # or 
  yarn add @oxide/design-system@1.2.11--canary.66.0131a65.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
