### PR TITLE
Summary title should not be italic

### DIFF
--- a/components/dist/asciidoc.css
+++ b/components/dist/asciidoc.css
@@ -575,6 +575,10 @@
     @apply mb-2 max-w-[40rem] text-left italic text-sans-lg text-tertiary;
   }
 
+  .asciidoc-body summary.title {
+    @apply not-italic;
+  }
+
   .asciidoc-body .conum {
     @apply inline-block;
   }

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -575,6 +575,10 @@
     @apply mb-2 max-w-[40rem] text-left italic text-sans-lg text-tertiary;
   }
 
+  .asciidoc-body summary.title {
+    @apply not-italic;
+  }
+
   .asciidoc-body .conum {
     @apply inline-block;
   }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.13--canary.68.68a5167.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @oxide/design-system@1.2.13--canary.68.68a5167.0
  # or 
  yarn add @oxide/design-system@1.2.13--canary.68.68a5167.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
