### PR TITLE
Fix nested table border issue

### DIFF
--- a/components/dist/asciidoc.css
+++ b/components/dist/asciidoc.css
@@ -559,8 +559,12 @@
     @apply border-r-0;
   }
 
-  .asciidoc-body tbody tr:last-child td,
-  .asciidoc-body tbody tr:last-child th {
+  /* 
+    specificity to handle nested tables 
+    todo: check if it's needed in any of the other table styles
+  */
+  .asciidoc-body tbody > tr:last-child > td,
+  .asciidoc-body tbody > tr:last-child > th {
     @apply border-b-0;
   }
 

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -559,8 +559,12 @@
     @apply border-r-0;
   }
 
-  .asciidoc-body tbody tr:last-child td,
-  .asciidoc-body tbody tr:last-child th {
+  /* 
+    specificity to handle nested tables 
+    todo: check if it's needed in any of the other table styles
+  */
+  .asciidoc-body tbody > tr:last-child > td,
+  .asciidoc-body tbody > tr:last-child > th {
     @apply border-b-0;
   }
 


### PR DESCRIPTION
Nested tables missing some borders. Added more CSS specificity to only apply to direct descendent.

<img width="845" alt="image" src="https://github.com/user-attachments/assets/a5627b0f-f943-44e7-a7fa-9693a57caa36">
