### PR TITLE
Make asciidoc summary title brighter

### DIFF
--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -528,7 +528,7 @@
   }
 
   .asciidoc-body summary.title {
-    @apply not-italic text-sans-xl text-raise;
+    @apply not-italic text-raise;
   }
 
   .asciidoc-body .conum {

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -528,7 +528,7 @@
   }
 
   .asciidoc-body summary.title {
-    @apply not-italic;
+    @apply not-italic text-sans-xl text-raise;
   }
 
   .asciidoc-body .conum {


### PR DESCRIPTION
### Before

<img width="607" alt="image" src="https://github.com/user-attachments/assets/ac6f02c1-64fe-4afa-b7a5-4106341b9b50">

### After

<img width="806" alt="image" src="https://github.com/user-attachments/assets/47df39de-4976-4a0d-befa-a48aa003f012">
