### PR TITLE
Tweak code size to use `em` not `rem`

### DIFF
--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -280,7 +280,7 @@
 
   .inline-code {
     @apply text-secondary;
-    @apply ml-[1px] mr-[1px] rounded border px-[4px] py-[1px] align-[1px] text-[0.825rem] bg-raise border-secondary;
+    @apply ml-[1px] mr-[1px] rounded border px-[4px] py-[1px] align-[1px] text-[0.825em] bg-raise border-secondary;
   }
 
   .asciidoc-body p code,
@@ -289,7 +289,7 @@
   .asciidoc-body h3 code,
   .asciidoc-body h4 code,
   .asciidoc-body h5 code {
-    @apply text-[0.825rem] text-default;
+    @apply text-[0.825em] text-default;
     @apply ml-[1px] mr-[1px] rounded border px-[4px] py-[1px] align-[1px] bg-raise border-secondary;
   }
 


### PR DESCRIPTION
Fits better with the flow of text