### PR TITLE
Don't depend on React Router or Remix directly

### DIFF
--- a/components/src/asciidoc/TableOfContents.tsx
+++ b/components/src/asciidoc/TableOfContents.tsx
@@ -8,7 +8,6 @@
 import { DirectionRightIcon } from '@/icons/react'
 import type { DocumentSection } from '@oxide/react-asciidoc'
 import * as Accordion from '@radix-ui/react-accordion'
-import { Link } from '@remix-run/react'
 import cn from 'classnames'
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -272,8 +271,8 @@ export const DesktopOutline = ({
           data-level={item.level}
           className={cn('mb-0 list-none text-sans-sm', item.level > 2 && 'hidden')}
         >
-          <Link
-            to={`#${item.id}`}
+          <a
+            href={`#${item.id}`}
             className={cn(
               'block border-l py-[4px] pr-4',
               activeItem === item.id
@@ -285,7 +284,7 @@ export const DesktopOutline = ({
             }}
           >
             <span dangerouslySetInnerHTML={{ __html: item.title }} />
-          </Link>
+          </a>
         </li>
         {item.sections && renderToc(item.sections)}
       </Fragment>
@@ -316,8 +315,8 @@ export const SmallScreenOutline = ({
           data-level={item.level}
           className={cn('list-none text-sans-sm', item.level > 2 && 'hidden')}
         >
-          <Link
-            to={`#${item.id}`}
+          <a
+            href={`#${item.id}`}
             onClick={() => setValue('')}
             className={cn(
               'block border-l py-[4px]',
@@ -330,7 +329,7 @@ export const SmallScreenOutline = ({
             }}
           >
             <span dangerouslySetInnerHTML={{ __html: item.title }} />
-          </Link>
+          </a>
         </li>
         {item.sections && renderToc(item.sections)}
       </Fragment>

--- a/components/src/asciidoc/use-delegated-links.ts
+++ b/components/src/asciidoc/use-delegated-links.ts
@@ -15,14 +15,28 @@
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
  */
-import { useNavigate } from '@remix-run/react'
 import { useEffect } from 'react'
+
+// copied from React Router, unlikely to change
+// https://github.com/remix-run/react-router/blob/7b041811/packages/react-router/lib/router/history.ts#L32-L50
+interface Path {
+  pathname: string
+  search: string
+  hash: string
+}
+
+// https://github.com/remix-run/react-router/blob/7b041811/packages/react-router/lib/router/history.ts#L101-L105
+type To = string | Partial<Path>
 
 // Converts regular AsciiDoc a tags and makes them React Routery
 // Added key so that this is reloaded when the user routes from one document to another directly
-function useDelegatedReactRouterLinks(nodeRef: React.RefObject<HTMLElement>, key: string) {
-  const navigate = useNavigate()
-
+function useDelegatedReactRouterLinks(
+  // this is to avoid a dependency on remix/react router
+  /** Pass in the result of `useNavigate()` in the calling application. */
+  navigate: (to: To) => void,
+  nodeRef: React.RefObject<HTMLElement>,
+  key: string,
+) {
   useEffect(() => {
     const node = nodeRef.current
     const handler = (event: MouseEvent) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
       "peerDependencies": {
         "@asciidoctor/core": "^3.0.0",
         "@oxide/react-asciidoc": "^1.0.0",
-        "@remix-run/react": "2.15.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
@@ -2764,80 +2763,6 @@
         }
       }
     },
-    "node_modules/@remix-run/react": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.15.2.tgz",
-      "integrity": "sha512-NAAMsSgoC/sdOgovUewwRCE/RUm3F+MBxxZKfwu3POCNeHaplY5qGkH/y8PUXvdN1EBG7Z0Ko43dyzCfcEy5PA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remix-run/router": "1.21.0",
-        "@remix-run/server-runtime": "2.15.2",
-        "react-router": "6.28.1",
-        "react-router-dom": "6.28.1",
-        "turbo-stream": "2.4.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "typescript": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
-      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@remix-run/server-runtime": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.15.2.tgz",
-      "integrity": "sha512-OqiPcvEnnU88B8b1LIWHHkQ3Tz2GDAmQ1RihFNQsbrFKpDsQLkw0lJlnfgKA/uHd0CEEacpfV7C9qqJT3V6Z2g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remix-run/router": "1.21.0",
-        "@types/cookie": "^0.6.0",
-        "@web3-storage/multipart-parser": "^1.0.0",
-        "cookie": "^0.6.0",
-        "set-cookie-parser": "^2.4.8",
-        "source-map": "^0.7.3",
-        "turbo-stream": "2.4.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@remix-run/server-runtime/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@resvg/resvg-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.4.1.tgz",
@@ -3659,13 +3584,6 @@
       "integrity": "sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==",
       "dev": true
     },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -4211,13 +4129,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@web3-storage/multipart-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
-      "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
-      "license": "(Apache-2.0 AND MIT)",
-      "peer": true
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.8",
@@ -5312,16 +5223,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/core-util-is": {
@@ -9793,40 +9694,6 @@
       "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
       "peer": true
     },
-    "node_modules/react-router": {
-      "version": "6.28.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.1.tgz",
-      "integrity": "sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remix-run/router": "1.21.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.28.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.1.tgz",
-      "integrity": "sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remix-run/router": "1.21.0",
-        "react-router": "6.28.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -10209,13 +10076,6 @@
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
@@ -11823,13 +11683,6 @@
         "@esbuild/win32-x64": "0.23.1"
       }
     },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC",
-      "peer": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -11872,7 +11725,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   "peerDependencies": {
     "@asciidoctor/core": "^3.0.0",
     "@oxide/react-asciidoc": "^1.0.0",
-    "@remix-run/react": "2.15.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Closes #86 

Will need to test it in an app that uses the delegated links hook to make sure passing `navigate` works as expected.

@charliepark and I ran into this while updating https://github.com/oxidecomputer/console/pull/2576 — there was a stray remaining `react-router-dom` import that should have errored out, but we had a dep on `react-router-dom` through design-system.