### PR TITLE
Update remix peer-dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "peerDependencies": {
         "@asciidoctor/core": "^3.0.0",
         "@oxide/react-asciidoc": "^1.0.0",
-        "@remix-run/react": "2.13.1",
+        "@remix-run/react": "2.15.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
@@ -2765,16 +2765,16 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.13.1.tgz",
-      "integrity": "sha512-kZevCoKMz0ZDOOzTnG95yfM7M9ju38FkWNY1wtxCy+NnUJYrmTerGQtiBsJgMzYD6i29+w4EwoQsdqys7DmMSg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.15.2.tgz",
+      "integrity": "sha512-NAAMsSgoC/sdOgovUewwRCE/RUm3F+MBxxZKfwu3POCNeHaplY5qGkH/y8PUXvdN1EBG7Z0Ko43dyzCfcEy5PA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.20.0",
-        "@remix-run/server-runtime": "2.13.1",
-        "react-router": "6.27.0",
-        "react-router-dom": "6.27.0",
+        "@remix-run/router": "1.21.0",
+        "@remix-run/server-runtime": "2.15.2",
+        "react-router": "6.28.1",
+        "react-router-dom": "6.28.1",
         "turbo-stream": "2.4.0"
       },
       "engines": {
@@ -2792,9 +2792,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
-      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
+      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2802,13 +2802,13 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.13.1.tgz",
-      "integrity": "sha512-2DfBPRcHKVzE4bCNsNkKB50BhCCKF73x+jiS836OyxSIAL+x0tguV2AEjmGXefEXc5AGGzoxkus0AUUEYa29Vg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.15.2.tgz",
+      "integrity": "sha512-OqiPcvEnnU88B8b1LIWHHkQ3Tz2GDAmQ1RihFNQsbrFKpDsQLkw0lJlnfgKA/uHd0CEEacpfV7C9qqJT3V6Z2g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.20.0",
+        "@remix-run/router": "1.21.0",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.6.0",
@@ -9794,13 +9794,13 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
-      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.1.tgz",
+      "integrity": "sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.20.0"
+        "@remix-run/router": "1.21.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -9810,14 +9810,14 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
-      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.1.tgz",
+      "integrity": "sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.20.0",
-        "react-router": "6.27.0"
+        "@remix-run/router": "1.21.0",
+        "react-router": "6.28.1"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "peerDependencies": {
     "@asciidoctor/core": "^3.0.0",
     "@oxide/react-asciidoc": "^1.0.0",
-    "@remix-run/react": "2.13.1",
+    "@remix-run/react": "2.15.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
* Bumps remix peer dep to 2.15.2

If https://github.com/oxidecomputer/design-system/pull/106 is merged, then this PR will not be needed, but until we decide on that it would be nice to have a version bump here for downstream repos.

I think this is technically a breaking change in that it requires downstream users to bump their peer dep if they have one.