### PR TITLE
Use inline for header titles (fix blog title spacing issue)

### DIFF
--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -112,7 +112,7 @@
     h3 a,
     h4 a,
     h5 a {
-      @apply flex items-center text-raise;
+      @apply inline text-raise;
     }
 
     h1[data-sectnum]:before,


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/oxide-computer/pull/487