### PR TITLE
Allow React 19 in peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,8 @@
       "peerDependencies": {
         "@asciidoctor/core": "^3.0.0",
         "@oxide/react-asciidoc": "^1.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   "peerDependencies": {
     "@asciidoctor/core": "^3.0.0",
     "@oxide/react-asciidoc": "^1.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": ">=18.2.0",
+    "react-dom": ">=18.2.0"
   },
   "dependencies": {
     "@floating-ui/react": "^0.25.1",


### PR DESCRIPTION
Just changing the peer deps might be insufficient. We might need to bump stuff like `@headlessui/react`.