### PR TITLE
Actually build the icons, move output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ scripts/*.md.mjs
 
 styles/dist
 components/dist
+dist/

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "exports": {
     "./styles/dist/*": "./styles/dist/*",
     "./components/dist/*.css": "./components/dist/*.css",
-    "./components/dist": "./components/dist/index.js",
-    "./icons": "./icons/index.js",
-    "./icons/react": "./icons/react/index.js",
+    "./components/dist": "./dist/components/src/index.js",
+    "./icons": "./dist/icons/index.js",
+    "./icons/react": "./dist/icons/react/index.js",
     ".": {
       "import": {
-        "types": "./components/dist/index.d.ts",
-        "default": "./components/dist/index.js"
+        "types": "./dist/components/src/index.d.ts",
+        "default": "./dist/components/src/index.js"
       }
     }
   },
@@ -79,8 +79,7 @@
   "files": [
     "styles/dist/*.css",
     "styles/dist/tailwind-tokens.ts",
-    "icons/**",
-    "components/dist/**"
+    "dist/**"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "files": [
     "styles/dist/*.css",
     "styles/dist/tailwind-tokens.ts",
+    "icons/**/*.svg",
     "dist/**"
   ],
   "repository": {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,9 +9,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   publicDir: 'components/src/assets/',
-  entry: ['components/src/index.ts'],
-  outDir: 'components/dist',
-  external: ['react/jsx-runtime'],
+  entry: ['components/src/index.ts', 'icons/index.ts', 'icons/react/index.ts'],
   sourcemap: true,
   clean: true,
   format: ['esm'],


### PR DESCRIPTION
I realized we are not actually building the icons for export: when I import the icons in console, I am just importing typescript source directly. I don't think that's how this is supposed to work.

I ran into this when trying to convert the console to use the React Router vite plugin instead of the standard Vite react plugin and it freaked out about the icon files. Not sure why the official plugin knows how to handle it — I compared the plugin source and could't figure out the relevant difference. The good news is this change fixes that: I tried it in my local branch and it all works out of the box with the RR vite plugin.

~~I need to make sure the icons are tree-shakeable, though. It might be a lot of useless bytes in the bundle if it insists on bringing in the entire set of icons instead of just the ones we use.~~ Tree-shaking works. Bundle is only marginally bigger.

### Changes

1. Add icons barrel files as explicit entries to tsup config so they get built
2. Move built output from `components/dist` to tsup default `dist`
3. Change package.json so imports from this library point to the new built output