### PR TITLE
Manually bump to 4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/design-system",
-  "version": "3.1.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/design-system",
-      "version": "3.1.0",
+      "version": "4.0.1",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/design-system",
-  "version": "3.1.0",
+  "version": "4.0.1",
   "description": "Home of reusable design assets and token for oxide internal sites",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
The release on 2d9ac1311854697b9e59251511c27fb19c9ae4de failed, claiming there was already a 4.0.0, which there isn't, so I don't know what that's about. Then I tried making another PR to make a patch release, which I realized halfway through would just bump 3.1.0 to 3.1.1. So here I am manually bumping to 4.0.1, and then we can figure out how to make this release later.