### PR TITLE
Use themes for admonitions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g. 6.0.2)"
+        description: 'Version to release (e.g. 6.0.2)'
         required: true
         type: string
   pull_request:
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: npm
       - run: npm install -g npm@latest
       - run: npm install
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: npm
       - run: npm install -g npm@latest
       - run: npm install

--- a/components/src/asciidoc/Admonition.tsx
+++ b/components/src/asciidoc/Admonition.tsx
@@ -9,8 +9,17 @@ import { Content, parse, Title, type AdmonitionBlock } from '@oxide/react-asciid
 
 import { titleCase } from '../utils'
 
+const themeForAdmonition: Record<string, string> = {
+  note: 'green-theme',
+  caution: 'yellow-theme',
+  important: 'yellow-theme',
+  warning: 'red-theme',
+  tip: 'purple-theme',
+}
+
 const Admonition = ({ node }: { node: AdmonitionBlock }) => {
   const attrs = node.attributes
+  const theme = themeForAdmonition[attrs.name] || ''
 
   let icon
   if (attrs.name === 'caution') {
@@ -22,7 +31,7 @@ const Admonition = ({ node }: { node: AdmonitionBlock }) => {
   }
 
   return (
-    <div className={`admonitionblock ${attrs.name}`}>
+    <div className={`admonitionblock ${attrs.name} ${theme}`}>
       <div className="admonition-icon">{icon}</div>
       <div className="admonition-content content">
         <Title text={node.title} />

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -383,25 +383,8 @@
       @apply text-accent;
     }
 
-    .admonitionblock.caution strong,
-    .admonitionblock.important strong {
-      @apply text-notice;
-    }
-
-    .admonitionblock.caution .quoteblock {
-      @apply border-notice-secondary;
-    }
-
-    .admonitionblock.warning .quoteblock {
-      @apply border-destructive-secondary;
-    }
-
-    .admonitionblock.warning strong {
-      @apply text-destructive;
-    }
-
-    .admonitionblock.tip strong {
-      color: var(--color-purple-800);
+    .admonitionblock .quoteblock {
+      @apply border-accent-secondary;
     }
 
     .admonitionblock,
@@ -409,70 +392,8 @@
       @apply text-accent;
     }
 
-    .admonitionblock.tip,
-    .admonitionblock.tip blockquote {
-      background-color: var(--color-purple-200);
-      color: var(--color-purple-800);
-      border-color: var(--color-purple-400);
-    }
-
-    .admonitionblock.caution,
-    .admonitionblock.important,
-    .admonitionblock.caution blockquote,
-    .admonitionblock.important blockquote {
-      @apply text-notice bg-notice border-notice-tertiary;
-    }
-
-    .admonitionblock.warning,
-    .admonitionblock.warning blockquote {
-      @apply text-destructive bg-destructive border-destructive-tertiary;
-    }
-
-    .admonitionblock.caution,
-    .admonitionblock.important {
-      @apply text-notice;
-    }
-
-    .admonitionblock.warning {
-      @apply text-destructive;
-    }
-
-    .admonitionblock.tip {
-      color: var(--color-purple-800);
-    }
-
-    .admonitionblock.caution p code,
-    .admonitionblock.important p code {
-      @apply bg-notice-inverse;
-    }
-
-    .admonitionblock.warning p code {
-      @apply bg-error-inverse;
-    }
-
-    .admonitionblock.tip p code {
-      @apply bg-purple-800;
-    }
-
     .admonitionblock a {
-      @apply underline;
-    }
-
-    .admonitionblock a {
-      @apply text-accent;
-    }
-
-    .admonitionblock.caution a,
-    .admonitionblock.important a {
-      @apply text-notice;
-    }
-
-    .admonitionblock.warning a {
-      @apply text-destructive;
-    }
-
-    .admonitionblock.tip a {
-      @apply text-purple-800;
+      @apply underline text-accent;
     }
 
     .admonition-icon svg {


### PR DESCRIPTION
Uses themes for admonitions making the CSS much simpler, and making the contents much less brittle especially if something less typical is nested inside that we haven't properly overridden.

**Canary:** `npm install @oxide/design-system@6.0.4-canary.7affc0f`