### PR TITLE
Add light mode syntax theme and `<code>` tweaks

### DIFF
--- a/components/src/asciidoc/oxide-syntax.json
+++ b/components/src/asciidoc/oxide-syntax.json
@@ -1,8 +1,8 @@
 {
   "name": "Oxide Dark",
   "colors": {
-    "editor.background": "#080F11",
-    "editor.foreground": "#E7E7E8"
+    "editor.background": "var(--syntax-bg)",
+    "editor.foreground": "var(--syntax-fg)"
   },
   "tokenColors": [
     {
@@ -13,32 +13,32 @@
         "punctuation.definition.variable"
       ],
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": "punctuation",
       "settings": {
-        "foreground": "#A1A4A5",
+        "foreground": "var(--syntax-comment)",
         "fontStyle": ""
       }
     },
     {
       "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
-        "foreground": "#A1A4A5"
+        "foreground": "var(--syntax-comment)"
       }
     },
     {
       "scope": ["string", "punctuation.definition.string"],
       "settings": {
-        "foreground": "#68D9A7"
+        "foreground": "var(--syntax-string)"
       }
     },
     {
       "scope": "constant.character.escape",
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
@@ -53,7 +53,7 @@
         "keyword.other.unit.suffix.floating-point"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -68,14 +68,14 @@
         "punctuation.definition.keyword"
       ],
       "settings": {
-        "foreground": "#C6A5EA",
+        "foreground": "var(--syntax-keyword)",
         "fontStyle": ""
       }
     },
     {
       "scope": "entity.name.tag.documentation",
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
@@ -88,7 +88,7 @@
         "punctuation.separator.key-value"
       ],
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
@@ -100,7 +100,7 @@
         "variable.function"
       ],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -112,31 +112,31 @@
         "entity.name.struct"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "entity.name.enum",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": ["meta.enum variable.other.readwrite", "variable.other.enummember"],
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "meta.property.object",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": ["meta.type", "meta.type-alias", "support.type", "entity.name.type"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -148,49 +148,49 @@
         "punctuation.decorator"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": ["variable.parameter", "meta.function.parameters"],
       "settings": {
-        "foreground": "#F39EAE"
+        "foreground": "var(--syntax-parameter)"
       }
     },
     {
       "scope": ["constant.language", "support.function.builtin"],
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": "entity.other.attribute-name.documentation",
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": ["keyword.control.directive", "punctuation.definition.directive"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "punctuation.definition.typeparameters",
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "entity.name.namespace",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "support.type.property-name.css",
       "settings": {
-        "foreground": "#9DAFFA",
+        "foreground": "var(--syntax-function)",
         "fontStyle": ""
       }
     },
@@ -200,19 +200,19 @@
         "variable.language.this punctuation.definition.variable"
       ],
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": "variable.object.property",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": ["string.template variable", "string variable"],
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
@@ -224,7 +224,7 @@
     {
       "scope": "storage.modifier.specifier.extern.cpp",
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
@@ -235,7 +235,7 @@
         "entity.name.scope-resolution.function.definition.cpp"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -247,19 +247,19 @@
     {
       "scope": ["storage.modifier.reference.cpp"],
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "meta.interpolation.cs",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": "comment.block.documentation.cs",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
@@ -268,38 +268,38 @@
         "entity.other.attribute-name.parent-selector.css punctuation.definition.entity.css"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "punctuation.separator.operator.css",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "source.css entity.other.attribute-name.pseudo-class",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "source.css constant.other.unicode-range",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "source.css variable.parameter.url",
       "settings": {
-        "foreground": "#88DCB7",
+        "foreground": "var(--syntax-operator)",
         "fontStyle": ""
       }
     },
     {
       "scope": ["support.type.vendored.property-name"],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -310,7 +310,7 @@
         "meta.definition.variable.scss"
       ],
       "settings": {
-        "foreground": "#F39EAE"
+        "foreground": "var(--syntax-parameter)"
       }
     },
     {
@@ -320,19 +320,19 @@
         "meta.property-list variable.other.less punctuation.definition.variable.less"
       ],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "keyword.other.unit.percentage.css",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "source.css meta.attribute-selector",
       "settings": {
-        "foreground": "#88DCB7"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
@@ -347,51 +347,51 @@
         "support.type.property-name.yaml"
       ],
       "settings": {
-        "foreground": "#9DAFFA",
+        "foreground": "var(--syntax-function)",
         "fontStyle": ""
       }
     },
     {
       "scope": ["constant.language.json", "constant.language.yaml"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": ["entity.name.type.anchor.yaml", "variable.other.alias.yaml"],
       "settings": {
-        "foreground": "#EDD5A6",
+        "foreground": "var(--syntax-number)",
         "fontStyle": ""
       }
     },
     {
       "scope": ["support.type.property-name.table", "entity.name.section.group-title.ini"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "constant.other.time.datetime.offset.toml",
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": ["punctuation.definition.anchor.yaml", "punctuation.definition.alias.yaml"],
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": "entity.other.document.begin.yaml",
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": "markup.changed.diff",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -402,85 +402,85 @@
         "punctuation.definition.to-file.diff"
       ],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "markup.inserted.diff",
       "settings": {
-        "foreground": "#88DCB7"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "markup.deleted.diff",
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": ["variable.other.env"],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": ["string.quoted variable.other.env"],
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": "support.function.builtin.gdscript",
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "constant.language.gdscript",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "comment meta.annotation.go",
       "settings": {
-        "foreground": "#F39EAE"
+        "foreground": "var(--syntax-parameter)"
       }
     },
     {
       "scope": "comment meta.annotation.parameters.go",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "constant.language.go",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "variable.graphql",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": "string.unquoted.alias.graphql",
       "settings": {
-        "foreground": "#F2CDCD"
+        "foreground": "var(--syntax-string-alias)"
       }
     },
     {
       "scope": "constant.character.enum.graphql",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "meta.objectvalues.graphql constant.object.key.graphql string.unquoted.graphql",
       "settings": {
-        "foreground": "#F2CDCD"
+        "foreground": "var(--syntax-string-alias)"
       }
     },
     {
@@ -491,13 +491,13 @@
         "meta.tag.metadata.doctype punctuation.definition.tag"
       ],
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": ["entity.name.tag"],
       "settings": {
-        "foreground": "#9DAFFA",
+        "foreground": "var(--syntax-function)",
         "fontStyle": ""
       }
     },
@@ -513,13 +513,13 @@
         "constant.character.entity.tsx punctuation"
       ],
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": ["entity.other.attribute-name"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -530,26 +530,26 @@
         "support.class.component.vue"
       ],
       "settings": {
-        "foreground": "#EFB7C2",
+        "foreground": "var(--syntax-escape)",
         "fontStyle": ""
       }
     },
     {
       "scope": ["punctuation.definition.annotation", "storage.type.annotation"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "constant.other.enum.java",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "storage.modifier.import.java",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
@@ -561,7 +561,7 @@
     {
       "scope": "meta.export variable.other.readwrite.js",
       "settings": {
-        "foreground": "#F39EAE"
+        "foreground": "var(--syntax-parameter)"
       }
     },
     {
@@ -572,13 +572,13 @@
         "variable.other.property.ts"
       ],
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": ["variable.other.jsdoc", "comment.block.documentation variable.other"],
       "settings": {
-        "foreground": "#F39EAE",
+        "foreground": "var(--syntax-parameter)",
         "fontStyle": ""
       }
     },
@@ -591,19 +591,19 @@
     {
       "scope": "support.type.object.console.js",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": ["support.constant.node", "support.type.object.module.js"],
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": "storage.modifier.implements",
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
@@ -615,25 +615,25 @@
         "support.type.builtin.ts"
       ],
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": "variable.parameter.generic",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": ["keyword.declaration.function.arrow.js", "storage.type.function.arrow.ts"],
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "punctuation.decorator.ts",
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -650,49 +650,49 @@
         "keyword.operator.expression.typeof.ts"
       ],
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": "support.function.macro.julia",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "constant.language.julia",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "constant.other.symbol.julia",
       "settings": {
-        "foreground": "#F39EAE"
+        "foreground": "var(--syntax-parameter)"
       }
     },
     {
       "scope": "text.tex keyword.control.preamble",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "text.tex support.function.be",
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "constant.other.general.math.tex",
       "settings": {
-        "foreground": "#F2CDCD"
+        "foreground": "var(--syntax-string-alias)"
       }
     },
     {
       "scope": "comment.line.double-dash.documentation.lua storage.type.annotation.lua",
       "settings": {
-        "foreground": "#C6A5EA",
+        "foreground": "var(--syntax-keyword)",
         "fontStyle": ""
       }
     },
@@ -702,7 +702,7 @@
         "comment.line.double-dash.documentation.lua variable.lua"
       ],
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
@@ -717,7 +717,7 @@
         "markup.heading.heading-0.asciidoc"
       ],
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
@@ -732,7 +732,7 @@
         "markup.heading.heading-1.asciidoc"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -746,7 +746,7 @@
         "markup.heading.heading-2.asciidoc"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -760,7 +760,7 @@
         "markup.heading.heading-3.asciidoc"
       ],
       "settings": {
-        "foreground": "#88DCB7"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
@@ -774,7 +774,7 @@
         "markup.heading.heading-4.asciidoc"
       ],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -788,33 +788,33 @@
         "markup.heading.heading-5.asciidoc"
       ],
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": "markup.bold",
       "settings": {
-        "foreground": "#F7869B",
+        "foreground": "var(--syntax-builtin)",
         "fontStyle": "bold"
       }
     },
     {
       "scope": "markup.italic",
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": "markup.strikethrough",
       "settings": {
-        "foreground": "#A6ADC8",
+        "foreground": "var(--syntax-comment)",
         "fontStyle": "strikethrough"
       }
     },
     {
       "scope": ["punctuation.definition.link", "markup.underline.link"],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -831,7 +831,7 @@
         "markup.substitution.attribute-reference"
       ],
       "settings": {
-        "foreground": "#B4BEFE"
+        "foreground": "var(--syntax-blue-pale)"
       }
     },
     {
@@ -844,13 +844,13 @@
         "markup.raw.block.quarto"
       ],
       "settings": {
-        "foreground": "#88DCB7"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "fenced_code.block.language",
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -859,19 +859,19 @@
         "markup.raw support.asciidoc"
       ],
       "settings": {
-        "foreground": "#A1A4A5"
+        "foreground": "var(--syntax-comment)"
       }
     },
     {
       "scope": ["markup.quote", "punctuation.definition.quote.begin"],
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": "meta.separator.markdown",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
@@ -881,7 +881,7 @@
         "markup.list.bullet"
       ],
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
@@ -896,52 +896,52 @@
         "entity.other.attribute-name.single.nix"
       ],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "variable.parameter.name.nix",
       "settings": {
-        "foreground": "#E7E7E8",
+        "foreground": "var(--syntax-fg)",
         "fontStyle": ""
       }
     },
     {
       "scope": "meta.embedded variable.parameter.name.nix",
       "settings": {
-        "foreground": "#B4BEFE",
+        "foreground": "var(--syntax-blue-pale)",
         "fontStyle": ""
       }
     },
     {
       "scope": "string.unquoted.path.nix",
       "settings": {
-        "foreground": "#EFB7C2",
+        "foreground": "var(--syntax-escape)",
         "fontStyle": ""
       }
     },
     {
       "scope": ["support.attribute.builtin", "meta.attribute.php"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "meta.function.parameters.php punctuation.definition.variable.php",
       "settings": {
-        "foreground": "#F39EAE"
+        "foreground": "var(--syntax-parameter)"
       }
     },
     {
       "scope": "constant.language.php",
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": "text.html.php support.function",
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -953,13 +953,13 @@
     {
       "scope": ["support.variable.magic.python", "meta.function-call.arguments.python"],
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": ["support.function.magic.python"],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -968,19 +968,19 @@
         "variable.language.special.self.python"
       ],
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": ["keyword.control.flow.python", "keyword.operator.logical.python"],
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": "storage.type.function.python",
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
@@ -989,13 +989,13 @@
         "meta.function.decorator.identifier.python"
       ],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": ["meta.function-call.python"],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -1004,43 +1004,43 @@
         "punctuation.definition.decorator.python"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "constant.character.format.placeholder.other.python",
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": ["support.type.exception.python", "support.function.builtin.python"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": ["support.type.python"],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "constant.language.python",
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": ["meta.indexed-name.python", "meta.item-access.python"],
       "settings": {
-        "foreground": "#F39EAE"
+        "foreground": "var(--syntax-parameter)"
       }
     },
     {
       "scope": "storage.type.string.python",
       "settings": {
-        "foreground": "#88DCB7"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
@@ -1055,19 +1055,19 @@
         "string.regexp punctuation.definition.string.end"
       ],
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": "keyword.control.anchor.regexp",
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": "string.regexp.ts",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
@@ -1076,37 +1076,37 @@
         "keyword.other.back-reference.regexp"
       ],
       "settings": {
-        "foreground": "#88DCB7"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "punctuation.definition.character-class.regexp",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "constant.other.character-class.regexp",
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": "constant.other.character-class.range.regexp",
       "settings": {
-        "foreground": "#F5E0DC"
+        "foreground": "var(--syntax-rose)"
       }
     },
     {
       "scope": "keyword.operator.quantifier.regexp",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "constant.character.numeric.regexp",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -1116,7 +1116,7 @@
         "meta.assertion.negative-look-ahead.regexp"
       ],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
@@ -1127,7 +1127,7 @@
         "punctuation.definition.attribute.rust"
       ],
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -1154,57 +1154,57 @@
         "storage.type.type.rust"
       ],
       "settings": {
-        "foreground": "#C6A5EA",
+        "foreground": "var(--syntax-keyword)",
         "fontStyle": ""
       }
     },
     {
       "scope": "entity.name.type.numeric.rust",
       "settings": {
-        "foreground": "#C6A5EA",
+        "foreground": "var(--syntax-keyword)",
         "fontStyle": ""
       }
     },
     {
       "scope": "meta.generic.rust",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "entity.name.impl.rust",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "entity.name.module.rust",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "entity.name.trait.rust",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "storage.type.source.rust",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "entity.name.union.rust",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": "meta.enum.rust storage.type.source.rust",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
@@ -1214,61 +1214,61 @@
         "entity.name.function.macro.rust"
       ],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": ["storage.modifier.lifetime.rust", "entity.name.type.lifetime"],
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "string.quoted.double.rust constant.other.placeholder.rust",
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": "meta.function.return-type.rust meta.generic.rust storage.type.rust",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": "meta.function.call.rust",
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "punctuation.brackets.angle.rust",
       "settings": {
-        "foreground": "#9DAFFA"
+        "foreground": "var(--syntax-function)"
       }
     },
     {
       "scope": "constant.other.caps.rust",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
       "scope": ["meta.function.definition.rust variable.other.rust"],
       "settings": {
-        "foreground": "#F39EAE"
+        "foreground": "var(--syntax-parameter)"
       }
     },
     {
       "scope": "meta.function.call.rust variable.other.rust",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": "variable.language.self.rust",
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
@@ -1277,7 +1277,7 @@
         "meta.macro.metavariable.rust keyword.operator.macro.dollar.rust"
       ],
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
@@ -1289,13 +1289,13 @@
         "meta.shebang.shell"
       ],
       "settings": {
-        "foreground": "#EFB7C2"
+        "foreground": "var(--syntax-escape)"
       }
     },
     {
       "scope": "comment.line.shebang constant.language",
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
@@ -1306,13 +1306,13 @@
         "meta.function-call.arguments.shell punctuation.section.interpolation"
       ],
       "settings": {
-        "foreground": "#F7869B"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": "meta.string meta.interpolation.parameter.shell variable.other.readwrite",
       "settings": {
-        "foreground": "#EDD5A6"
+        "foreground": "var(--syntax-number)"
       }
     },
     {
@@ -1321,43 +1321,43 @@
         "punctuation.definition.evaluation.backticks.shell"
       ],
       "settings": {
-        "foreground": "#A7E0C8"
+        "foreground": "var(--syntax-operator)"
       }
     },
     {
       "scope": "entity.name.tag.heredoc.shell",
       "settings": {
-        "foreground": "#C6A5EA"
+        "foreground": "var(--syntax-keyword)"
       }
     },
     {
       "scope": "string.quoted.double.shell variable.other.normal.shell",
       "settings": {
-        "foreground": "#E7E7E8"
+        "foreground": "var(--syntax-fg)"
       }
     },
     {
       "scope": "token.info-token",
       "settings": {
-        "foreground": "#8BA1FF"
+        "foreground": "var(--syntax-blue)"
       }
     },
     {
       "scope": "token.warn-token",
       "settings": {
-        "foreground": "#F5B944"
+        "foreground": "var(--syntax-amber)"
       }
     },
     {
       "scope": "token.error-token",
       "settings": {
-        "foreground": "#FB6E88"
+        "foreground": "var(--syntax-builtin)"
       }
     },
     {
       "scope": "token.debug-token",
       "settings": {
-        "foreground": "#BE95EB"
+        "foreground": "var(--syntax-purple)"
       }
     }
   ]

--- a/components/src/asciidoc/util.ts
+++ b/components/src/asciidoc/util.ts
@@ -28,7 +28,7 @@ import {
 } from 'shiki'
 
 import oxqlLang from './langs/oxql.tmLanguage.json'
-import theme from './oxide-dark.json'
+import theme from './oxide-syntax.json'
 
 let highlighter: HighlighterGeneric<BundledLanguage, BundledTheme> | null = null
 const customLanguages = ['oxql']

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -25,8 +25,9 @@
 }
 
 @utility inline-code {
-  @apply text-secondary;
-  @apply ml-[1px] mr-[1px] rounded-md border px-[4px] py-[1px] align-[1px] text-[0.825em] bg-raise border-secondary;
+  @apply mr-[1px] ml-[1px] rounded-md border px-0.5 align-[1px] text-[0.825em] tracking-normal!;
+  background-color: color-mix(in srgb, currentColor 8%, transparent);
+  border-color: color-mix(in srgb, currentColor 10%, transparent);
 }
 
 @layer components {
@@ -36,7 +37,7 @@
     }
 
     .quoteblock {
-      @apply mb-8 mt-8 border-l pl-[1.6rem] text-secondary border-default;
+      @apply text-secondary border-default mt-8 mb-8 border-l pl-[1.6rem];
     }
 
     .quoteblock p {
@@ -44,7 +45,7 @@
     }
 
     .quoteblock .attribution {
-      @apply mt-8 text-raise;
+      @apply text-raise mt-8;
     }
 
     .attribution cite {
@@ -52,7 +53,7 @@
     }
 
     .admonitionblock .quoteblock {
-      @apply mb-2 mt-2 pl-[0.75rem] border-accent-secondary;
+      @apply border-accent-secondary mt-2 mb-2 pl-[0.75rem];
     }
 
     .admonition-content .paragraph {
@@ -60,11 +61,11 @@
     }
 
     .admonition-content > div:first-of-type {
-      @apply normal-case text-sans-semi-md;
+      @apply text-sans-semi-md normal-case;
     }
 
     .imageblock img {
-      @apply mx-auto h-auto w-auto w-full rounded-lg border border-tertiary object-contain;
+      @apply border-tertiary mx-auto h-auto w-auto w-full rounded-lg border object-contain;
       max-height: max(500px, 75vh);
     }
 
@@ -87,7 +88,7 @@
 
     /* Use semi-bold for strong */
     strong {
-      @apply font-[500] text-raise;
+      @apply text-raise font-[500];
     }
 
     a strong {
@@ -98,7 +99,7 @@
     h3,
     h4,
     h5 {
-      @apply relative mb-3 mt-10 text-raise;
+      @apply text-raise relative mt-10 mb-3;
     }
 
     /* Removes top spacing from header if it is the first element */
@@ -115,7 +116,7 @@
     h3 a,
     h4 a,
     h5 a {
-      @apply inline text-raise;
+      @apply text-raise inline;
     }
 
     h1[data-sectnum]:before,
@@ -123,7 +124,7 @@
     h3[data-sectnum]:before,
     h4[data-sectnum]:before,
     h5[data-sectnum]:before {
-      @apply bottom-0 mr-2 inline-block text-tertiary 800:absolute 800:-left-[72px] 800:mr-0 800:w-[60px] 800:text-right 800:text-sans-lg;
+      @apply text-tertiary 800:absolute 800:-left-[72px] 800:mr-0 800:w-[60px] 800:text-right 800:text-sans-lg bottom-0 mr-2 inline-block;
     }
 
     h3[data-sectnum]:before,
@@ -141,7 +142,7 @@
 
     h4,
     h5 {
-      @apply mb-2 mt-8 text-sans-lg text-raise;
+      @apply text-sans-lg text-raise mt-8 mb-2;
     }
 
     .anchor,
@@ -167,7 +168,7 @@
     }
 
     p {
-      @apply mb-[1.25rem] !leading-[1.5] text-sans-lg 800:mb-3;
+      @apply text-sans-lg 800:mb-3 mb-[1.25rem] !leading-[1.5];
     }
 
     ul li,
@@ -177,7 +178,7 @@
 
     ul,
     ol {
-      @apply mb-3 list-disc text-mono-sm;
+      @apply text-mono-sm mb-3 list-disc;
     }
 
     li::marker,
@@ -219,7 +220,7 @@
 
     ul,
     ol {
-      @apply list-inside 800:list-outside;
+      @apply 800:list-outside list-inside;
     }
 
     ul:first-of-type,
@@ -246,7 +247,7 @@
     .ulist .olist,
     .olist .ulist,
     .olist .olist {
-      @apply ml-[2rem] 800:ml-2;
+      @apply 800:ml-2 ml-[2rem];
     }
 
     .exampleblock ul,
@@ -288,35 +289,20 @@
     }
 
     ol p {
-      @apply normal-case text-default;
+      @apply text-default normal-case;
     }
 
-    p code,
-    h1 code,
-    h2 code,
-    h3 code,
-    h4 code,
-    h5 code,
-    .title code {
-      @apply text-[0.825em] text-default;
-      @apply ml-[1px] mr-[1px] rounded-md border px-[4px] py-[1px] align-[1px] bg-raise border-secondary;
-    }
-
-    p a code {
-      @apply text-accent-secondary;
+    :not(pre) > code {
+      @apply inline-code;
     }
 
     table p code {
       @apply break-normal;
     }
 
-    .admonitionblock p code {
-      @apply border-none text-inverse bg-accent-inverse;
-    }
-
     pre {
-      @apply rounded-lg border px-[1.25rem] py-[1rem] border-secondary 800:px-[1.75rem] 800:py-[1.5rem];
-      @apply overflow-x-auto !text-[13px] text-mono-code;
+      @apply border-secondary 800:px-[1.75rem] 800:py-[1.5rem] rounded-lg border px-[1.25rem] py-[1rem];
+      @apply text-mono-code overflow-x-auto !text-[13px];
     }
 
     code {
@@ -332,12 +318,12 @@
     }
 
     .listingblock code[data-lang]:before {
-      @apply absolute right-2 top-2 block text-mono-xs text-secondary;
+      @apply text-mono-xs text-secondary absolute top-2 right-2 block;
       content: attr(data-lang);
     }
 
     pre .conum[data-value] {
-      @apply relative -top-[0.125rem] inline-block h-[1rem] min-w-[1rem] rounded-full text-center not-italic text-mono-xs text-secondary bg-raise;
+      @apply text-mono-xs text-secondary bg-raise relative -top-[0.125rem] inline-block h-[1rem] min-w-[1rem] rounded-full text-center not-italic;
     }
 
     pre .conum[data-value]:after {
@@ -350,11 +336,11 @@
     }
 
     .exampleblock {
-      @apply overflow-x-auto rounded-lg px-[1.5rem] py-[1.25rem] bg-raise;
+      @apply bg-raise overflow-x-auto rounded-lg px-[1.5rem] py-[1.25rem];
     }
 
     .exampleblock p {
-      @apply mb-2 text-sans-md;
+      @apply text-sans-md mb-2;
     }
 
     .exampleblock .content,
@@ -367,7 +353,7 @@
     }
 
     .admonitionblock {
-      @apply rounded-lg border text-accent bg-accent border-accent-tertiary;
+      @apply text-accent bg-accent border-accent-tertiary rounded-lg border;
       @apply my-[1.5rem] flex px-3 py-3;
     }
 
@@ -393,11 +379,11 @@
     }
 
     .admonitionblock a {
-      @apply underline text-accent;
+      @apply text-accent underline;
     }
 
     .admonition-icon svg {
-      @apply mr-2 mt-0.5 h-3 w-3;
+      @apply mt-0.5 mr-2 h-3 w-3;
     }
 
     .admonition-content {
@@ -405,7 +391,7 @@
     }
 
     .admonition-content p {
-      @apply mb-0 text-sans-md;
+      @apply text-sans-md mb-0;
     }
 
     .imageblock,
@@ -426,7 +412,7 @@
     }
 
     .imageblock .title {
-      @apply mt-3 max-w-full text-center not-italic text-mono-xs text-secondary;
+      @apply text-mono-xs text-secondary mt-3 max-w-full text-center not-italic;
     }
 
     img.wide {
@@ -454,11 +440,11 @@
     }
 
     .title {
-      @apply mb-2 max-w-[40rem] text-left italic text-sans-lg text-secondary;
+      @apply text-sans-lg text-secondary mb-2 max-w-[40rem] text-left italic;
     }
 
     summary.title {
-      @apply not-italic text-raise;
+      @apply text-raise not-italic;
     }
 
     .conum {
@@ -478,7 +464,7 @@
     }
 
     table {
-      @apply w-full border-separate overflow-hidden rounded-lg border p-0 border-secondary;
+      @apply border-secondary w-full border-separate overflow-hidden rounded-lg border p-0;
       border-spacing: 0;
     }
 
@@ -496,7 +482,7 @@
 
     table td,
     table th {
-      @apply border-b border-r px-[0.5rem] py-[0.5rem] align-top border-secondary;
+      @apply border-secondary border-r border-b px-[0.5rem] py-[0.5rem] align-top;
     }
 
     table tr th:last-child {
@@ -517,7 +503,7 @@
     }
 
     table th {
-      @apply text-left text-mono-xs text-secondary bg-raise;
+      @apply text-mono-xs text-secondary bg-raise text-left;
     }
 
     table th p {
@@ -545,7 +531,7 @@
     }
 
     .colist table tr td:first-of-type {
-      @apply w-[1%] whitespace-nowrap text-tertiary;
+      @apply text-tertiary w-[1%] whitespace-nowrap;
     }
 
     .colist table b {
@@ -553,7 +539,7 @@
     }
 
     div.bibliography ~ h2 {
-      @apply mt-12 800:mt-16;
+      @apply 800:mt-16 mt-12;
     }
 
     .bibliography ul,
@@ -562,7 +548,7 @@
     }
 
     mark {
-      @apply rounded-md px-[2px] text-notice bg-notice;
+      @apply text-notice bg-notice rounded-md px-[2px];
     }
 
     .steminline svg {
@@ -570,11 +556,11 @@
     }
 
     hr {
-      @apply my-3 border-default;
+      @apply border-default my-3;
     }
 
     .sidebarblock {
-      @apply bg-raise p-4 rounded-lg my-8 px-6 py-5;
+      @apply bg-raise my-8 rounded-lg p-4 px-6 py-5;
     }
 
     .halign-left {
@@ -607,7 +593,7 @@
 
     a:not(:is(h1, h2, h3, h4, h5, h6) a) {
       text-decoration-color: color-mix(in srgb, currentColor 60%, transparent);
-      @apply underline text-accent-secondary;
+      @apply text-accent-secondary underline;
     }
   }
 
@@ -615,16 +601,9 @@
     @apply accent-link;
   }
 
-  #footnotes p code {
-    @apply inline-code;
-  }
-
-  .toc .active code {
-    @apply border-accent-tertiary;
-  }
-
+  #footnotes p code,
   .toc code {
-    @apply ml-[1px] mr-[1px] rounded-md border px-[3px] align-[1px] border-secondary;
+    @apply inline-code;
   }
 
   @media screen and (min-width: 720px) {

--- a/preview/App.tsx
+++ b/preview/App.tsx
@@ -3,6 +3,7 @@ import './index.css'
 import { useState } from 'react'
 
 import { Badge, Button, Checkbox, Spinner, Tabs } from '../components/src/ui'
+import { CodeBlock } from './CodeBlock'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -117,6 +118,231 @@ function ComponentShowcase() {
             <p className="text-sans-md text-secondary">Content for tab three</p>
           </Tabs.Content>
         </Tabs.Root>
+      </Section>
+
+      <Section title="Syntax highlighting (Rust)">
+        <CodeBlock
+          lang="rust"
+          code={`fn main() {
+    let greeting = "Hello, world!";
+    let count: u32 = 42;
+    println!("{} ({})", greeting, count);
+
+    let nums = vec![1, 2, 3];
+    let sum: u32 = nums.iter().sum();
+    println!("sum = {}", sum);
+}`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (TypeScript)">
+        <CodeBlock
+          lang="tsx"
+          code={`/**
+ * @module example
+ * Comprehensive syntax demo for the Oxide Dark theme.
+ */
+import { useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+
+const PI = 3.14159
+const HEX = 0xff00aa
+const ENABLED = true
+const NAME: string = 'world\\n'
+const RE = /^[a-z]+\\d{2,}$/i
+
+enum Status {
+  Idle = 'idle',
+  Loading = 'loading',
+  Ready = 'ready',
+}
+
+interface Greeter<T extends string> {
+  readonly name: T
+  greet(loud?: boolean): string
+}
+
+type Props = {
+  message: string
+  count?: number
+  children?: ReactNode
+}
+
+class Hello implements Greeter<'hello'> {
+  readonly name = 'hello' as const
+  static #instances = 0
+
+  constructor(private prefix: string = '>>') {
+    Hello.#instances += 1
+  }
+
+  greet(loud = false): string {
+    const out = \`\${this.prefix} \${NAME.toUpperCase()}\`
+    return loud ? out.repeat(2) : out
+  }
+}
+
+async function load(url: string): Promise<Status> {
+  try {
+    const res = await fetch(url)
+    return res.ok ? Status.Ready : Status.Idle
+  } catch (err) {
+    console.error('failed', err)
+    return Status.Idle
+  }
+}
+
+export function Counter({ message, count = 0, children }: Props) {
+  const [n, setN] = useState<number>(count)
+  useEffect(() => { void load('/ping') }, [])
+
+  return (
+    <section className="counter" data-status={n > 0 ? 'on' : 'off'}>
+      <h1>{message}</h1>
+      <button onClick={() => setN((c) => c + 1)} disabled={n >= 10}>
+        Clicked {n} times
+      </button>
+      {children ?? <em>no children</em>}
+    </section>
+  )
+}`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (JSON)">
+        <CodeBlock
+          lang="json"
+          code={`{
+  "name": "test/system",
+  "version": "6.0.5",
+  "private": false,
+  "dependencies": {
+    "shiki": "^3.13.0",
+    "react": "^18.0.0"
+  },
+  "scripts": {
+    "preview:dev": "vite --config preview/vite.config.ts"
+  }
+}`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (YAML)">
+        <CodeBlock
+          lang="yaml"
+          code={`---
+# service config
+service: &svc web-api
+config:
+  enabled: true
+  retries: 3
+  hosts:
+    - example.com
+    - 127.0.0.1
+fallback: *svc`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (TOML)">
+        <CodeBlock
+          lang="toml"
+          code={`# config
+title = "Example"
+enabled = true
+retries = 3
+created = 2026-04-17T08:00:00Z
+
+[server]
+host = "example.com"
+port = 8080`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (CSS)">
+        <CodeBlock
+          lang="css"
+          code={`/* sample stylesheet */
+:root {
+  --brand: #ff6785;
+}
+
+.button[data-variant="primary"]:hover {
+  color: var(--brand);
+  font-size: 1.25rem;
+  padding: 8px 12px;
+  background: linear-gradient(90deg, #08f 0%, #80f 100%);
+}`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (diff)">
+        <CodeBlock
+          lang="diff"
+          code={`--- a/file.ts
++++ b/file.ts
+@@ -1,4 +1,4 @@
+ export function greet(name) {
+-  return "hi " + name
++  return \`hello \${name}\`
+ }`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (Markdown)">
+        <CodeBlock
+          lang="md"
+          code={`# Heading 1
+## Heading 2
+
+A paragraph with **bold**, *italic*, and \`inline code\`.
+
+> A blockquote.
+
+- list item one
+- list item two
+
+[link text](https://example.com)`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (Go)">
+        <CodeBlock
+          lang="go"
+          code={`// Package main is a demo.
+package main
+
+import "fmt"
+
+//go:generate echo "hello"
+
+// Server holds connection settings.
+type Server struct {
+\tHost string
+\tPort int
+}
+
+func main() {
+\ts := Server{Host: "localhost", Port: 8080}
+\tfmt.Printf("server on %s:%d\\n", s.Host, s.Port)
+}`}
+        />
+      </Section>
+
+      <Section title="Syntax highlighting (GraphQL)">
+        <CodeBlock
+          lang="graphql"
+          code={`# fetch a user
+query GetUser($id: ID!) {
+  user(id: $id) {
+    name: fullName
+    role
+    posts(limit: 5) {
+      title
+      tags
+    }
+  }
+}`}
+        />
       </Section>
     </div>
   )

--- a/preview/CodeBlock.tsx
+++ b/preview/CodeBlock.tsx
@@ -1,0 +1,48 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import { useEffect, useState } from 'react'
+
+import { getHighlighter, themeName } from './highlighter'
+
+type Props = {
+  code: string
+  lang?: string
+}
+
+export function CodeBlock({ code, lang = 'tsx' }: Props) {
+  const [html, setHtml] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getHighlighter().then((h) => {
+      if (cancelled) return
+      setHtml(
+        h.codeToHtml(code, {
+          lang,
+          theme: themeName,
+        }),
+      )
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [code, lang])
+
+  return (
+    <div
+      className="text-mono-code [&_pre]:overflow-x-auto [&_pre]:p-4"
+      dangerouslySetInnerHTML={{
+        __html: html ?? `<pre><code>${escape(code)}</code></pre>`,
+      }}
+    />
+  )
+}
+
+function escape(s: string) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}

--- a/preview/highlighter.ts
+++ b/preview/highlighter.ts
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * Copyright Oxide Computer Company
+ */
+import {
+  createHighlighter,
+  type BundledLanguage,
+  type BundledTheme,
+  type HighlighterGeneric,
+} from 'shiki'
+
+import theme from '../components/src/asciidoc/oxide-syntax.json'
+
+let highlighterPromise: Promise<HighlighterGeneric<BundledLanguage, BundledTheme>> | null =
+  null
+
+export const themeName = theme.name
+
+export function getHighlighter() {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: [theme],
+      langs: ['tsx', 'rust', 'json', 'yaml', 'toml', 'css', 'diff', 'md', 'go', 'graphql'],
+    })
+  }
+  return highlighterPromise
+}

--- a/styles/dark.css
+++ b/styles/dark.css
@@ -92,6 +92,25 @@
   --stroke-info-secondary: var(--theme-info-600);
   --stroke-info-tertiary: var(--theme-info-400);
   --stroke-info-quaternary: var(--theme-info-300);
+
+  /* Syntax highlighting (consumed by oxide shiki theme) */
+  --syntax-bg: var(--color-neutral-0);
+  --syntax-fg: var(--color-neutral-1000);
+  --syntax-comment: var(--color-neutral-700);
+  --syntax-string: var(--color-green-1000);
+  --syntax-operator: var(--color-green-1100);
+  --syntax-number: var(--color-yellow-1100);
+  --syntax-amber: var(--color-yellow-800);
+  --syntax-keyword: var(--color-purple-900);
+  --syntax-purple: var(--color-purple-800);
+  --syntax-function: var(--color-blue-900);
+  --syntax-blue: var(--color-blue-800);
+  --syntax-blue-pale: var(--color-blue-1000);
+  --syntax-builtin: var(--color-red-900);
+  --syntax-parameter: var(--color-red-1000);
+  --syntax-escape: var(--color-red-1100);
+  --syntax-string-alias: var(--color-red-1200);
+  --syntax-rose: var(--color-red-1300);
 }
 
 :root,

--- a/styles/light.css
+++ b/styles/light.css
@@ -91,6 +91,25 @@
   --stroke-success-secondary: var(--theme-success-600);
   --stroke-success-tertiary: var(--theme-success-400);
   --stroke-success-quaternary: var(--theme-success-300);
+
+  /* Syntax highlighting (consumed by oxide shiki theme) */
+  --syntax-bg: var(--color-neutral-1300);
+  --syntax-fg: var(--color-neutral-500);
+  --syntax-comment: var(--color-neutral-700);
+  --syntax-string: var(--color-green-600);
+  --syntax-operator: var(--color-green-500);
+  --syntax-number: var(--color-yellow-600);
+  --syntax-amber: var(--color-yellow-700);
+  --syntax-keyword: var(--color-purple-600);
+  --syntax-purple: var(--color-purple-700);
+  --syntax-function: var(--color-blue-600);
+  --syntax-blue: var(--color-blue-700);
+  --syntax-blue-pale: var(--color-blue-500);
+  --syntax-builtin: var(--color-red-600);
+  --syntax-parameter: var(--color-red-500);
+  --syntax-escape: var(--color-red-400);
+  --syntax-string-alias: var(--color-red-400);
+  --syntax-rose: var(--color-red-300);
 }
 
 [data-theme="light"],

--- a/token-sync/src/ui/ui.tsx
+++ b/token-sync/src/ui/ui.tsx
@@ -1,10 +1,12 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import './styles.css';
-import App from './App.tsx';
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import './styles.css'
+
+import App from './App.tsx'
 
 createRoot(document.getElementById('app')!).render(
-	<StrictMode>
-		<App />
-	</StrictMode>,
-);
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)


### PR DESCRIPTION
Adjusted the current theme to use the new expanded gamut vars directly. Use CSS vars which are remapped for dark and light modes.

Dark:
<img width="546" height="885" alt="image" src="https://github.com/user-attachments/assets/e19a7481-5c25-483f-bcef-7af12dc37a11" />

Light:
<img width="545" height="896" alt="image" src="https://github.com/user-attachments/assets/5585b0f3-0d8b-40e1-a7e0-5ac783de1d62" />

Bonus tweak to the `<code>` style. Currently I had to target them individually. This way it infers the style from its context meaning it's less brittle. E.g. within an admonition.

Fixes #54 

**Canary:** `npm install @oxide/design-system@6.0.5-canary.d34267a`