### PR TITLE
Prevent asciidoc styles from leaking into mermaid SVG

### DIFF
--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -163,8 +163,14 @@
     }
 
     /* Fix overflow text in mermaid */
-    figure svg {
+    code svg {
       line-height: 1 !important;
+    }
+
+    /* Prevent asciidoc styles from leaking into mermaid SVG output */
+    code svg,
+    code svg * {
+      all: revert-layer;
     }
 
     p {


### PR DESCRIPTION
Fixes #130
Related https://github.com/oxidecomputer/rfd-site/issues/196

**Canary:** `npm install @oxide/design-system@6.1.1-canary.ca702ad`