### PR TITLE
Integrate `rfd-site` asciidoc styles

### DIFF
--- a/components/src/asciidoc/Admonition.tsx
+++ b/components/src/asciidoc/Admonition.tsx
@@ -5,7 +5,7 @@
  *
  * Copyright Oxide Computer Company
  */
-import { Content, parse, Title, type AdmonitionBlock } from '@oxide/react-asciidoc'
+import { Content, parse, type AdmonitionBlock } from '@oxide/react-asciidoc'
 
 import { titleCase } from '../utils'
 
@@ -34,10 +34,9 @@ const Admonition = ({ node }: { node: AdmonitionBlock }) => {
     <div className={`admonitionblock ${attrs.name} ${theme}`}>
       <div className="admonition-icon">{icon}</div>
       <div className="admonition-content content">
-        <Title text={node.title} />
         <div>{titleCase(attrs.name.toString())}</div>
         <div>
-          <Title text={node.title} />
+          <div className="admonition-title">{node.title}</div>
           {node.content && parse(node.content)}
           <Content blocks={node.blocks} />
         </div>

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -61,7 +61,7 @@
     }
 
     .admonition-content > div:first-of-type {
-      @apply text-sans-semi-md normal-case;
+      @apply text-sans-semi-md;
     }
 
     .admonition-content .admonition-title {
@@ -74,11 +74,11 @@
     }
 
     span img {
-      @apply inline;
+      @apply inline bg-transparent;
     }
 
-    img.transparent-dark {
-      @apply bg-secondary;
+    img {
+      @apply bg-raise;
     }
 
     p a {
@@ -103,11 +103,11 @@
     }
 
     /* Removes top spacing from header if it is the first element */
-    &#content > .sect1:first-of-type > h1:nth-child(1),
-    &#content > .sect1:first-of-type > h2:nth-child(1),
-    &#content > .sect1:first-of-type > h3:nth-child(1),
-    &#content > .sect1:first-of-type > h4:nth-child(1),
-    &#content > .sect1:first-of-type > h5:nth-child(1) {
+    &#content > .sect1:first-of-type > h1:nth-child(2),
+    &#content > .sect1:first-of-type > h2:nth-child(2),
+    &#content > .sect1:first-of-type > h3:nth-child(2),
+    &#content > .sect1:first-of-type > h4:nth-child(2),
+    &#content > .sect1:first-of-type > h5:nth-child(2) {
       @apply mt-0;
     }
 
@@ -124,12 +124,26 @@
     h3[data-sectnum]:before,
     h4[data-sectnum]:before,
     h5[data-sectnum]:before {
-      @apply text-tertiary 800:absolute 800:-left-[72px] 800:mr-0 800:w-[60px] 800:text-right 800:text-sans-lg bottom-0 mr-2 inline-block;
+      @apply text-tertiary 800:absolute 800:-left-[72px] 800:mr-0 800:w-[60px] 800:text-right 800:text-sans-lg pointer-events-none top-[6px] mr-2 inline-block;
+      content: attr(data-sectnum);
     }
 
     h3[data-sectnum]:before,
     h2[data-sectnum]:before {
-      @apply 800:bottom-[2px];
+      @apply top-[2px];
+    }
+
+    h4[data-sectnum]:before,
+    h5[data-sectnum]:before {
+      @apply top-0;
+    }
+
+    h1[data-sectnum] a:after,
+    h2[data-sectnum] a:after,
+    h3[data-sectnum] a:after,
+    h4[data-sectnum] a:after,
+    h5[data-sectnum] a:after {
+      @apply hidden;
     }
 
     h2 {
@@ -323,7 +337,7 @@
     }
 
     pre .conum[data-value] {
-      @apply text-mono-xs text-secondary bg-raise relative -top-[0.125rem] inline-block h-[1rem] min-w-[1rem] rounded-full text-center not-italic;
+      @apply text-mono-xs text-accent bg-accent-secondary-hover relative -top-[0.125rem] inline-block h-[1rem] min-w-[1rem] rounded-full text-center not-italic;
     }
 
     pre .conum[data-value]:after {
@@ -453,6 +467,10 @@
 
     .table-wrapper {
       @apply relative overflow-x-auto;
+    }
+
+    .table-wrapper caption a:hover:after {
+      @apply align-[-2px];
     }
 
     .table-wrapper caption {

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -64,6 +64,10 @@
       @apply text-sans-semi-md normal-case;
     }
 
+    .admonition-content .admonition-title {
+      @apply italic mb-2;
+    }
+
     .imageblock img {
       @apply border-tertiary mx-auto h-auto w-auto w-full rounded-lg border object-contain;
       max-height: max(500px, 75vh);

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -347,7 +347,7 @@
     }
 
     pre .conum[data-value] {
-      @apply text-mono-xs text-accent bg-accent-secondary-hover relative -top-[0.125rem] inline-block h-[1rem] min-w-[1rem] rounded-full text-center not-italic;
+      @apply text-mono-xs text-accent bg-accent-hover relative -top-[0.125rem] inline-block h-[1rem] min-w-[1rem] rounded-full text-center not-italic;
     }
 
     pre .conum[data-value]:after {

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -107,11 +107,12 @@
     }
 
     /* Removes top spacing from header if it is the first element */
-    &#content > .sect1:first-of-type > h1:nth-child(2),
-    &#content > .sect1:first-of-type > h2:nth-child(2),
-    &#content > .sect1:first-of-type > h3:nth-child(2),
-    &#content > .sect1:first-of-type > h4:nth-child(2),
-    &#content > .sect1:first-of-type > h5:nth-child(2) {
+    #preamble .sectionbody > *:first-child,
+    #content > .sect1:first-of-type > h1,
+    #content > .sect1:first-of-type > h2,
+    #content > .sect1:first-of-type > h3,
+    #content > .sect1:first-of-type > h4,
+    #content > .sect1:first-of-type > h5 {
       @apply mt-0;
     }
 

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -91,12 +91,8 @@
     }
 
     /* Use semi-bold for strong */
-    strong {
+    strong:not(a strong) {
       @apply text-raise font-[500];
-    }
-
-    a strong {
-      @apply text-accent-secondary;
     }
 
     h2,


### PR DESCRIPTION
Moving a bunch that were in the RFD site repo into here

**Canary:** `npm install @oxide/design-system@6.1.1-canary.70eddd2`