### PR TITLE
Release v6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oxide/design-system",
-  "version": "6.1.4",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oxide/design-system",
-      "version": "6.1.4",
+      "version": "6.2.0",
       "license": "MPL 2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxide/design-system",
-  "version": "6.1.4",
+  "version": "6.2.0",
   "description": "Home of reusable design assets and token for oxide internal sites",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Recovery PR: the release workflow published v6.2.0 to npm and pushed the tag, but the master push was blocked by branch protection. This PR lands the version bump commit so master matches the published tag.