### PR TITLE
Fix remove margin on first element

### DIFF
--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -68,7 +68,7 @@
 
     /* Remove top spacing from the first heading in a document */
     #preamble .sectionbody > *:first-child,
-    #content > .sect1:first-of-type > :is(h1, h2, h3, h4, h5) {
+    & > .sect1:first-of-type > :is(h1, h2, h3, h4, h5) {
       margin-top: 0;
     }
 


### PR DESCRIPTION
It's nested with `.asciidoc-body` so targetting `#content` doesnt work here (`#content` is on `.asciidoc-body` not a child).

**Canary:** `npm install @oxide/design-system@6.2.0-canary.d8e9792`