### PR TITLE
Responsive Typography

### DIFF
--- a/preview/App.tsx
+++ b/preview/App.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 
 import { Badge, Button, Checkbox, Spinner, Tabs } from '../components/src/ui'
 import { CodeBlock } from './CodeBlock'
+import { TypographyShowcase } from './TypographyShowcase'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -374,35 +375,52 @@ table mcast_replication_ipv6 {
   )
 }
 
-const headerToggleClass =
-  'text-mono-sm text-secondary hover:text-default hover:bg-hover rounded-md px-3 py-1.5'
+const headerToggleClass = 'text-mono-sm hover:bg-hover rounded-md px-3 py-1.5'
 
 export default function App() {
   const [mode, setMode] = useState<'dark' | 'light'>('dark')
+  const [view, setView] = useState<'components' | 'typography'>('components')
 
   return (
     <div className={mode === 'light' ? 'light' : undefined} data-theme={mode}>
       <div className="bg-default text-default min-h-screen">
-        <div className="border-secondary bg-default sticky top-0 flex items-center justify-between border-b px-4 py-2">
-          <h1 className="text-sans-lg text-raise">Component Preview</h1>
-          <div className="flex gap-1">
+        <div className="text-tertiary border-secondary bg-default sticky top-0 z-20 flex items-center justify-between border-b px-2 py-2">
+          <div className="flex gap-px">
+            <button
+              onClick={() => setView('components')}
+              className={`${headerToggleClass} ${view === 'components' && 'text-raise'}`}
+            >
+              Components
+            </button>
+            <button
+              onClick={() => setView('typography')}
+              className={`${headerToggleClass} ${view === 'typography' && 'text-raise'}`}
+            >
+              Typography
+            </button>
+          </div>
+          <div className="flex gap-px">
             <button
               onClick={() => setMode('dark')}
-              className={`${headerToggleClass} ${mode === 'dark' && 'bg-tertiary'}`}
+              className={`${headerToggleClass} ${mode === 'dark' && 'text-raise'}`}
             >
               Dark
             </button>
             <button
               onClick={() => setMode('light')}
-              className={`${headerToggleClass} ${mode === 'light' && 'bg-tertiary'}`}
+              className={`${headerToggleClass} ${mode === 'light' && 'text-raise'}`}
             >
               Light
             </button>
           </div>
         </div>
-        <div className="mx-auto flex max-w-4xl flex-col gap-8 p-8">
-          <ComponentShowcase />
-        </div>
+        {view === 'components' ? (
+          <div className="mx-auto flex max-w-4xl flex-col gap-8 p-8">
+            <ComponentShowcase />
+          </div>
+        ) : (
+          <TypographyShowcase />
+        )}
       </div>
     </div>
   )

--- a/preview/TypographyShowcase.tsx
+++ b/preview/TypographyShowcase.tsx
@@ -65,15 +65,31 @@ function PrimitiveRow({ utility }: { utility: string }) {
   )
 }
 
-const PRIMITIVES = [
-  'text-sans-sm',
-  'text-sans-md',
-  'text-sans-lg',
-  'text-sans-xl',
-  'text-sans-2xl',
-  'text-sans-3xl',
-  'text-sans-4xl',
-  'text-sans-5xl',
+const NUMERIC_PRIMITIVES = [
+  'text-sans-11',
+  'text-sans-12',
+  'text-sans-14',
+  'text-sans-16',
+  'text-sans-18',
+  'text-sans-20',
+  'text-sans-22',
+  'text-sans-25',
+  'text-sans-28',
+  'text-sans-36',
+  'text-sans-50',
+  'text-sans-52',
+  'text-sans-65',
+]
+
+const SEMANTIC_ALIASES: Array<[string, string]> = [
+  ['text-sans-sm', '→ 12'],
+  ['text-sans-md', '→ 14'],
+  ['text-sans-lg', '→ 16'],
+  ['text-sans-xl', '→ 18'],
+  ['text-sans-2xl', '→ 25'],
+  ['text-sans-3xl', '→ 36'],
+  ['text-sans-4xl', '→ 52'],
+  ['text-sans-5xl', '→ 65'],
 ]
 
 export function TypographyShowcase() {
@@ -107,10 +123,26 @@ export function TypographyShowcase() {
           />
         </section>
 
-        <section>
-          <h2 className="text-sans-2xl text-secondary mb-2">Primitives</h2>
-          {PRIMITIVES.map((utility) => (
+        <section className="mb-16">
+          <h2 className="text-sans-2xl text-secondary mb-2">Numeric primitives</h2>
+          {NUMERIC_PRIMITIVES.map((utility) => (
             <PrimitiveRow key={utility} utility={utility} />
+          ))}
+        </section>
+
+        <section>
+          <h2 className="text-sans-2xl text-secondary mb-2">Semantic aliases</h2>
+          {SEMANTIC_ALIASES.map(([utility, alias]) => (
+            <div
+              key={utility}
+              className="border-secondary flex items-baseline gap-6 border-b py-4"
+            >
+              <span className="text-mono-xs text-tertiary w-32 shrink-0">{utility}</span>
+              <span className="text-mono-xs text-quaternary w-20 shrink-0">{alias}</span>
+              <span className={`${utility} text-raise`}>
+                The quick brown fox jumps over the lazy dog
+              </span>
+            </div>
           ))}
         </section>
       </div>

--- a/preview/TypographyShowcase.tsx
+++ b/preview/TypographyShowcase.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+
+function useViewportWidth() {
+  const [width, setWidth] = useState(() =>
+    typeof window === 'undefined' ? 0 : window.innerWidth,
+  )
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+  return width
+}
+
+const BREAKPOINTS = [600, 800, 1000]
+
+function ViewportRuler({ width }: { width: number }) {
+  return (
+    <div className="border-secondary bg-raise sticky top-11 z-10 flex items-center gap-4 border-b px-5 py-2">
+      <span className="text-mono-sm text-raise tabular-nums">{width}px</span>
+      <div className="flex gap-3">
+        {BREAKPOINTS.map((bp) => (
+          <span
+            key={bp}
+            className={`text-mono-xs ${width >= bp ? 'text-accent' : 'text-tertiary'}`}
+          >
+            ≥{bp}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SemanticRow({
+  name,
+  utility,
+  steps,
+}: {
+  name: string
+  utility: string
+  steps: string
+}) {
+  return (
+    <div className="border-secondary flex flex-col gap-3 border-b py-8">
+      <div className="text-mono-xs text-tertiary flex items-baseline justify-between gap-4">
+        <span>{name}</span>
+        <span>{steps}</span>
+      </div>
+      <div className={`${utility} text-raise`}>
+        The quick brown fox jumps over the lazy dog
+      </div>
+    </div>
+  )
+}
+
+function PrimitiveRow({ utility }: { utility: string }) {
+  return (
+    <div className="border-secondary flex items-baseline gap-6 border-b py-4">
+      <span className="text-mono-xs text-tertiary w-32 shrink-0">{utility}</span>
+      <span className={`${utility} text-raise`}>
+        The quick brown fox jumps over the lazy dog
+      </span>
+    </div>
+  )
+}
+
+const PRIMITIVES = [
+  'text-sans-sm',
+  'text-sans-md',
+  'text-sans-lg',
+  'text-sans-xl',
+  'text-sans-2xl',
+  'text-sans-3xl',
+  'text-sans-4xl',
+  'text-sans-5xl',
+]
+
+export function TypographyShowcase() {
+  const width = useViewportWidth()
+
+  return (
+    <div>
+      <ViewportRuler width={width} />
+      <div className="px-8 py-12">
+        <h2 className="text-sans-2xl text-secondary mb-2">Semantic</h2>
+        <section className="mb-16">
+          <SemanticRow
+            name="heading-display"
+            utility="heading-display"
+            steps="3xl → 4xl @800 → 65 @1000"
+          />
+          <SemanticRow
+            name="heading-xl"
+            utility="heading-xl"
+            steps="2xl → 3xl @600 → 4xl @1000"
+          />
+          <SemanticRow
+            name="heading-lg"
+            utility="heading-lg"
+            steps="xl → 2xl @600 → 3xl @1000"
+          />
+          <SemanticRow
+            name="heading-md"
+            utility="heading-md"
+            steps="lg → xl @600 → 2xl @1000"
+          />
+        </section>
+
+        <section>
+          <h2 className="text-sans-2xl text-secondary mb-2">Primitives</h2>
+          {PRIMITIVES.map((utility) => (
+            <PrimitiveRow key={utility} utility={utility} />
+          ))}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -412,7 +412,7 @@
   font-weight: 400;
   line-height: 1rem;
   font-size: 0.75rem;
-  letter-spacing: 0.04rem;
+  letter-spacing: 0.01rem;
 }
 /* @figma sans/regular/md */
 @utility text-sans-md {
@@ -420,7 +420,7 @@
   font-weight: 400;
   line-height: 1.125rem;
   font-size: 0.875rem;
-  letter-spacing: 0.03rem;
+  letter-spacing: 0.01rem;
 }
 /* @figma sans/regular/lg */
 @utility text-sans-lg {
@@ -428,7 +428,7 @@
   font-weight: 400;
   line-height: 1.375rem;
   font-size: 1rem;
-  letter-spacing: 0.0175rem;
+  letter-spacing: 0.01rem;
 }
 /* @figma sans/regular/xl */
 @utility text-sans-xl {
@@ -436,7 +436,7 @@
   font-weight: 400;
   line-height: 1.5rem;
   font-size: 1.125rem;
-  letter-spacing: 0.0125rem;
+  letter-spacing: 0rem;
 }
 /* @figma sans/regular/2xl */
 @utility text-sans-2xl {
@@ -444,7 +444,7 @@
   font-weight: 400;
   line-height: 2rem;
   font-size: 1.5625rem;
-  letter-spacing: 0.015rem;
+  letter-spacing: 0rem;
 }
 /* @figma sans/regular/3xl */
 @utility text-sans-3xl {
@@ -452,7 +452,7 @@
   font-weight: 400;
   line-height: 2.625rem;
   font-size: 2.25rem;
-  letter-spacing: 0.005rem;
+  letter-spacing: -0.01rem;
 }
 /* @figma sans/regular/4xl */
 @utility text-sans-4xl {
@@ -460,7 +460,58 @@
   font-weight: 400;
   line-height: 3.625rem;
   font-size: 3.25rem;
-  letter-spacing: -0.01rem;
+  letter-spacing: -0.02rem;
+}
+/* @figma sans/regular/5xl */
+@utility text-sans-5xl {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  line-height: 3.65625rem;
+  font-size: 4.0625rem;
+  letter-spacing: -0.03rem;
+}
+/* Responsive heading semantic tokens
+ *
+ * heading-display  text-sans-3xl → 4xl@800 → 65@1000   hero / banner titles
+ * heading-xl       text-sans-2xl → 3xl@600 → 4xl@1000  primary section h2s
+ * heading-lg       text-sans-xl  → 2xl@600 → 3xl@1000  secondary headings (h3)
+ * heading-md       text-sans-lg  → xl@600  → 2xl@1000  subsection headings (h4)
+ */
+@utility heading-display {
+  @apply text-sans-3xl;
+  @media (min-width: 800px) {
+    @apply text-sans-4xl;
+  }
+  @media (min-width: 1000px) {
+    @apply text-sans-5xl;
+  }
+}
+@utility heading-xl {
+  @apply text-sans-2xl;
+  @media (min-width: 600px) {
+    @apply text-sans-3xl;
+  }
+  @media (min-width: 1000px) {
+    @apply text-sans-4xl;
+  }
+}
+@utility heading-lg {
+  @apply text-sans-xl;
+  @media (min-width: 600px) {
+    @apply text-sans-2xl;
+  }
+  @media (min-width: 1000px) {
+    @apply text-sans-3xl;
+  }
+}
+@utility heading-md {
+  @apply text-sans-lg;
+  @media (min-width: 600px) {
+    @apply text-sans-xl;
+  }
+  @media (min-width: 1000px) {
+    @apply text-sans-2xl;
+  }
 }
 /* @figma sans/semi/sm */
 @utility text-sans-semi-sm {

--- a/styles/main.css
+++ b/styles/main.css
@@ -409,93 +409,93 @@
 /* Sans primitives
  *
  * Letter-spacing follows an optical curve: tracking ∝ 1/size, expressed in em
- * so it scales with the type. Formula: letter-spacing = 0.861 / size − 0.0383 (em),
- * fitted to +0.040em at 11px and −0.025em at 65px. Small text opens up for
- * legibility; display sizes tighten. Zero crossing sits around 22px.
+ * so it scales with the type. Formula: letter-spacing = 0.981 / size − 0.0401 (em),
+ * fitted to +0.030em at 14px and −0.025em at 65px. Small text opens up for
+ * legibility; display sizes tighten. Zero crossing sits around 24px.
  */
 @utility text-sans-11 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 135%;
   font-size: 0.6875rem;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.049em;
 }
 @utility text-sans-12 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 1rem;
   font-size: 0.75rem;
-  letter-spacing: 0.033em;
+  letter-spacing: 0.042em;
 }
 @utility text-sans-14 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 1.125rem;
   font-size: 0.875rem;
-  letter-spacing: 0.023em;
+  letter-spacing: 0.030em;
 }
 @utility text-sans-16 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 1.375rem;
   font-size: 1rem;
-  letter-spacing: 0.016em;
+  letter-spacing: 0.021em;
 }
 @utility text-sans-18 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 1.5rem;
   font-size: 1.125rem;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.014em;
 }
 @utility text-sans-20 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 130%;
   font-size: 1.25rem;
-  letter-spacing: 0.005em;
+  letter-spacing: 0.009em;
 }
 @utility text-sans-22 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 130%;
   font-size: 1.375rem;
-  letter-spacing: 0em;
+  letter-spacing: 0.004em;
 }
 @utility text-sans-25 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 2rem;
   font-size: 1.5625rem;
-  letter-spacing: -0.004em;
+  letter-spacing: 0em;
 }
 @utility text-sans-28 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 120%;
   font-size: 1.75rem;
-  letter-spacing: -0.008em;
+  letter-spacing: -0.005em;
 }
 @utility text-sans-36 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 2.625rem;
   font-size: 2.25rem;
-  letter-spacing: -0.014em;
+  letter-spacing: -0.013em;
 }
 @utility text-sans-50 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 110%;
   font-size: 3.125rem;
-  letter-spacing: -0.021em;
+  letter-spacing: -0.020em;
 }
 @utility text-sans-52 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 3.625rem;
   font-size: 3.25rem;
-  letter-spacing: -0.022em;
+  letter-spacing: -0.021em;
 }
 @utility text-sans-65 {
   font-family: var(--font-sans);

--- a/styles/main.css
+++ b/styles/main.css
@@ -406,111 +406,180 @@
     'ss08' on,
     'calt' off;
 }
-/* @figma sans/regular/sm */
-@utility text-sans-sm {
+/* Sans primitives
+ *
+ * Letter-spacing follows an optical curve: tracking ∝ 1/size, expressed in em
+ * so it scales with the type. Formula: letter-spacing = 0.861 / size − 0.0383 (em),
+ * fitted to +0.040em at 11px and −0.025em at 65px. Small text opens up for
+ * legibility; display sizes tighten. Zero crossing sits around 22px.
+ */
+@utility text-sans-11 {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  line-height: 135%;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+}
+@utility text-sans-12 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 1rem;
   font-size: 0.75rem;
-  letter-spacing: 0.01rem;
+  letter-spacing: 0.033em;
 }
-/* @figma sans/regular/md */
-@utility text-sans-md {
+@utility text-sans-14 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 1.125rem;
   font-size: 0.875rem;
-  letter-spacing: 0.01rem;
+  letter-spacing: 0.023em;
 }
-/* @figma sans/regular/lg */
-@utility text-sans-lg {
+@utility text-sans-16 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 1.375rem;
   font-size: 1rem;
-  letter-spacing: 0.01rem;
+  letter-spacing: 0.016em;
 }
-/* @figma sans/regular/xl */
-@utility text-sans-xl {
+@utility text-sans-18 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 1.5rem;
   font-size: 1.125rem;
-  letter-spacing: 0rem;
+  letter-spacing: 0.01em;
 }
-/* @figma sans/regular/2xl */
-@utility text-sans-2xl {
+@utility text-sans-20 {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  line-height: 130%;
+  font-size: 1.25rem;
+  letter-spacing: 0.005em;
+}
+@utility text-sans-22 {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  line-height: 130%;
+  font-size: 1.375rem;
+  letter-spacing: 0em;
+}
+@utility text-sans-25 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 2rem;
   font-size: 1.5625rem;
-  letter-spacing: 0rem;
+  letter-spacing: -0.004em;
 }
-/* @figma sans/regular/3xl */
-@utility text-sans-3xl {
+@utility text-sans-28 {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  line-height: 120%;
+  font-size: 1.75rem;
+  letter-spacing: -0.008em;
+}
+@utility text-sans-36 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 2.625rem;
   font-size: 2.25rem;
-  letter-spacing: -0.01rem;
+  letter-spacing: -0.014em;
 }
-/* @figma sans/regular/4xl */
-@utility text-sans-4xl {
+@utility text-sans-50 {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  line-height: 110%;
+  font-size: 3.125rem;
+  letter-spacing: -0.021em;
+}
+@utility text-sans-52 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 3.625rem;
   font-size: 3.25rem;
-  letter-spacing: -0.02rem;
+  letter-spacing: -0.022em;
 }
-/* @figma sans/regular/5xl */
-@utility text-sans-5xl {
+@utility text-sans-65 {
   font-family: var(--font-sans);
   font-weight: 400;
   line-height: 3.65625rem;
   font-size: 4.0625rem;
-  letter-spacing: -0.03rem;
+  letter-spacing: -0.025em;
 }
+
+/* Sans semantic tokens */
+/* @figma sans/regular/sm */
+@utility text-sans-sm {
+  @apply text-sans-12;
+}
+/* @figma sans/regular/md */
+@utility text-sans-md {
+  @apply text-sans-14;
+}
+/* @figma sans/regular/lg */
+@utility text-sans-lg {
+  @apply text-sans-16;
+}
+/* @figma sans/regular/xl */
+@utility text-sans-xl {
+  @apply text-sans-18;
+}
+/* @figma sans/regular/2xl */
+@utility text-sans-2xl {
+  @apply text-sans-25;
+}
+/* @figma sans/regular/3xl */
+@utility text-sans-3xl {
+  @apply text-sans-36;
+}
+/* @figma sans/regular/4xl */
+@utility text-sans-4xl {
+  @apply text-sans-52;
+}
+/* @figma sans/regular/5xl */
+@utility text-sans-5xl {
+  @apply text-sans-65;
+}
+
 /* Responsive heading semantic tokens
  *
- * heading-display  text-sans-3xl → 4xl@800 → 65@1000   hero / banner titles
- * heading-xl       text-sans-2xl → 3xl@600 → 4xl@1000  primary section h2s
- * heading-lg       text-sans-xl  → 2xl@600 → 3xl@1000  secondary headings (h3)
- * heading-md       text-sans-lg  → xl@600  → 2xl@1000  subsection headings (h4)
+ * heading-display  36 → 52@800 → 65@1000  hero / banner titles
+ * heading-xl       25 → 36@600 → 52@1000  primary section h2s
+ * heading-lg       18 → 25@600 → 36@1000  secondary headings (h3)
+ * heading-md       16 → 18@600 → 25@1000  subsection headings (h4)
  */
 @utility heading-display {
-  @apply text-sans-3xl;
+  @apply text-sans-36;
   @media (min-width: 800px) {
-    @apply text-sans-4xl;
+    @apply text-sans-52;
   }
   @media (min-width: 1000px) {
-    @apply text-sans-5xl;
+    @apply text-sans-65;
   }
 }
 @utility heading-xl {
-  @apply text-sans-2xl;
+  @apply text-sans-25;
   @media (min-width: 600px) {
-    @apply text-sans-3xl;
+    @apply text-sans-36;
   }
   @media (min-width: 1000px) {
-    @apply text-sans-4xl;
+    @apply text-sans-52;
   }
 }
 @utility heading-lg {
-  @apply text-sans-xl;
+  @apply text-sans-18;
   @media (min-width: 600px) {
-    @apply text-sans-2xl;
+    @apply text-sans-25;
   }
   @media (min-width: 1000px) {
-    @apply text-sans-3xl;
+    @apply text-sans-36;
   }
 }
 @utility heading-md {
-  @apply text-sans-lg;
+  @apply text-sans-16;
   @media (min-width: 600px) {
-    @apply text-sans-xl;
+    @apply text-sans-18;
   }
   @media (min-width: 1000px) {
-    @apply text-sans-2xl;
+    @apply text-sans-25;
   }
 }
 /* @figma sans/semi/sm */

--- a/token-sync/src/main/main.ts
+++ b/token-sync/src/main/main.ts
@@ -11,6 +11,7 @@ import type {
 import { COLLECTION_PREFIX_MAP, tokenKey } from '../shared/types'
 import { readFigmaTextStyles, readFigmaVariables } from './read-figma-styles'
 import {
+  createTextStyle,
   createVariable,
   initCache,
   removeTextStyle,
@@ -192,9 +193,9 @@ async function applyChanges(settings: ApplySettings) {
       }
 
       if (entry.status === 'added' && settings.applyAdded && fileToken) {
-        // Typography styles can't be auto-created yet
-        if (isTypography) continue
-        const ok = await createVariable(entry.name, fileToken)
+        const ok = isTypography
+          ? await createTextStyle(entry.name, fileToken)
+          : await createVariable(entry.name, fileToken)
         if (ok) added++
         else failed++
       }

--- a/token-sync/src/main/write-figma-variables.ts
+++ b/token-sync/src/main/write-figma-variables.ts
@@ -167,25 +167,8 @@ export async function updateTextStyle(
   if (!style) return false
 
   try {
-    // Must load the font before modifying any text style properties
     await figma.loadFontAsync(style.fontName)
-
-    const props = JSON.parse(fileToken.value)
-
-    if (props.fontSize) {
-      style.fontSize = cssToPixels(props.fontSize)
-    }
-    if (props.lineHeight) {
-      if (props.lineHeight === 'auto') {
-        style.lineHeight = { unit: 'AUTO' }
-      } else {
-        style.lineHeight = { value: cssToPixels(props.lineHeight), unit: 'PIXELS' }
-      }
-    }
-    if (props.letterSpacing !== undefined) {
-      style.letterSpacing = { value: cssToPixels(props.letterSpacing), unit: 'PIXELS' }
-    }
-
+    applyTypographyProps(style, JSON.parse(fileToken.value))
     return true
   } catch (err) {
     console.error(`Failed to update text style ${name}:`, err)
@@ -193,11 +176,144 @@ export async function updateTextStyle(
   }
 }
 
-/** Convert a CSS length (e.g. "0.75rem", "12px", "12") to a pixel number. */
-function cssToPixels(val: string): number {
-  const remMatch = String(val).match(/^([\d.]+)rem$/)
-  if (remMatch) return parseFloat(remMatch[1]) * 16
-  return parseFloat(val)
+/**
+ * Create a new Figma text style from a file token.
+ * Borrows the FontName from an existing style with the same family and weight
+ * so the font family string is an exact match for what Figma expects.
+ */
+export async function createTextStyle(
+  name: string,
+  fileToken: FlatToken,
+): Promise<boolean> {
+  try {
+    const props = JSON.parse(fileToken.value)
+    const figmaName = name.replace(/\./g, '/')
+
+    const fontName = await findFontName(props.fontFamily, props.fontWeight)
+    if (!fontName) {
+      console.error(`No reference font found for ${name} (${props.fontFamily} ${props.fontWeight})`)
+      return false
+    }
+
+    await figma.loadFontAsync(fontName)
+    const style = figma.createTextStyle()
+    style.name = figmaName
+    style.fontName = fontName
+    applyTypographyProps(style, props)
+    return true
+  } catch (err) {
+    console.error(`Failed to create text style ${name}:`, err)
+    return false
+  }
+}
+
+/** Apply parsed typography props to a TextStyle node, respecting CSS units. */
+function applyTypographyProps(style: TextStyle, props: Record<string, string>): void {
+  if (props.fontSize) {
+    const px = parseCssLength(props.fontSize)
+    if (px !== null) style.fontSize = px.value
+  }
+  if (props.lineHeight) {
+    const parsed = parseCssLengthWithUnit(props.lineHeight)
+    if (parsed) {
+      style.lineHeight =
+        parsed.unit === 'AUTO'
+          ? { unit: 'AUTO' }
+          : { value: parsed.value, unit: parsed.unit }
+    }
+  }
+  if (props.letterSpacing !== undefined) {
+    const parsed = parseCssLengthWithUnit(props.letterSpacing)
+    if (parsed && parsed.unit !== 'AUTO') {
+      style.letterSpacing = { value: parsed.value, unit: parsed.unit }
+    }
+  }
+}
+
+type CssLength = { value: number; unit: 'PIXELS' | 'PERCENT' } | { unit: 'AUTO' }
+
+/**
+ * Parse a CSS length value to a Figma-compatible unit+value pair.
+ *
+ * rem  → PIXELS (×16)
+ * px   → PIXELS
+ * em   → PERCENT (×100, since 1em = 100% of font-size — matches how Figma
+ *         stores and reads back em-derived letter-spacing)
+ * %    → PERCENT
+ * auto → AUTO
+ */
+function parseCssLengthWithUnit(val: string): CssLength | null {
+  const s = String(val).trim()
+  if (s === 'auto') return { unit: 'AUTO' }
+  const remMatch = s.match(/^(-?[\d.]+)rem$/)
+  if (remMatch) return { value: parseFloat(remMatch[1]) * 16, unit: 'PIXELS' }
+  const pxMatch = s.match(/^(-?[\d.]+)px$/)
+  if (pxMatch) return { value: parseFloat(pxMatch[1]), unit: 'PIXELS' }
+  const emMatch = s.match(/^(-?[\d.]+)em$/)
+  if (emMatch) return { value: parseFloat(emMatch[1]) * 100, unit: 'PERCENT' }
+  const pctMatch = s.match(/^(-?[\d.]+)%$/)
+  if (pctMatch) return { value: parseFloat(pctMatch[1]), unit: 'PERCENT' }
+  const num = parseFloat(s)
+  if (!isNaN(num)) return { value: num, unit: 'PIXELS' }
+  return null
+}
+
+/** Parse a CSS length to pixels only (for font-size). */
+function parseCssLength(val: string): { value: number } | null {
+  const parsed = parseCssLengthWithUnit(val)
+  if (!parsed || parsed.unit === 'AUTO') return null
+  if (parsed.unit === 'PIXELS') return { value: parsed.value }
+  return null
+}
+
+const WEIGHT_TO_FONT_STYLE: Record<string, string[]> = {
+  '400': ['Regular', 'Regular OCC', 'Book'],
+  '500': ['Medium', 'Medium OCC', 'Semi'],
+}
+
+/**
+ * Find a Figma FontName by borrowing from an existing text style that matches
+ * the target family and weight. This avoids hard-coding the exact style string
+ * (e.g. "Regular OCC" vs "Regular") which varies per typeface.
+ */
+async function findFontName(
+  cssFamily: string,
+  cssWeight: string,
+): Promise<FontName | null> {
+  const styles = await figma.getLocalTextStylesAsync()
+  const targetWeight = Number(cssWeight)
+
+  for (const style of styles) {
+    // Match family loosely — CSS has "Suisse Int'l", Figma may have "Suisse Int'l OCC"
+    if (!style.fontName.family.startsWith(cssFamily.replace(/'/g, "'"))) continue
+    const w = weightFromStyleName(style.fontName.style)
+    if (w === targetWeight) return style.fontName
+  }
+
+  // Fallback: try loading the canonical style names for the weight
+  const candidates = WEIGHT_TO_FONT_STYLE[cssWeight] ?? ['Regular']
+  for (const styleName of candidates) {
+    try {
+      const fontName = { family: cssFamily, style: styleName }
+      await figma.loadFontAsync(fontName)
+      return fontName
+    } catch {
+      // try next candidate
+    }
+  }
+
+  return null
+}
+
+const WEIGHT_MAP: Record<string, number> = {
+  regular: 400, book: 400, normal: 400,
+  medium: 500, semi: 500, semibold: 600,
+  bold: 700, extrabold: 800, black: 900,
+}
+
+function weightFromStyleName(styleName: string): number {
+  const firstWord = styleName.split(/\s+/)[0].toLowerCase()
+  return WEIGHT_MAP[firstWord] ?? -1
 }
 
 async function findTextStyleByName(name: string): Promise<TextStyle | null> {

--- a/token-sync/src/shared/compare.ts
+++ b/token-sync/src/shared/compare.ts
@@ -161,12 +161,25 @@ function cssWeightToNumber(val: string): number {
   return WEIGHT_MAP[firstWord] ?? -1
 }
 
-/** Convert a CSS length value to pixels. Handles rem, px, and plain numbers. */
+/**
+ * Normalise a CSS length to a single numeric scale for comparison.
+ *
+ * rem  → pixels (×16)
+ * em   → percent-equivalent (×100), matching how Figma stores and reads back
+ *        em-derived letter-spacing as a PERCENT value
+ * %    → the bare percentage number
+ * px   → the bare pixel number
+ * auto → -1 (sentinel)
+ */
 function toPixels(val: string): number {
   if (val === 'auto') return -1
-  const remMatch = val.match(/^([\d.]+)rem$/)
+  const remMatch = val.match(/^(-?[\d.]+)rem$/)
   if (remMatch) return Math.round(parseFloat(remMatch[1]) * 16 * 100) / 100
-  const pxMatch = val.match(/^([\d.]+)px$/)
+  const emMatch = val.match(/^(-?[\d.]+)em$/)
+  if (emMatch) return Math.round(parseFloat(emMatch[1]) * 100 * 1000) / 1000
+  const pctMatch = val.match(/^(-?[\d.]+)%$/)
+  if (pctMatch) return parseFloat(pctMatch[1])
+  const pxMatch = val.match(/^(-?[\d.]+)px$/)
   if (pxMatch) return parseFloat(pxMatch[1])
   const num = parseFloat(val)
   return isNaN(num) ? -1 : num

--- a/token-sync/src/shared/parse-css.ts
+++ b/token-sync/src/shared/parse-css.ts
@@ -25,16 +25,14 @@ export function parseCSSTokens(css: CSSFiles): Map<string, FlatToken> {
     parseBaseTokens(themeBlock, result)
   }
 
-  // Parse dark mode semantic tokens
-  const darkBlock = extractBlock(css.dark, /:root\s*\{/)
-  if (darkBlock) {
-    parsePropsInto(darkBlock, 'dark', result)
+  // Parse dark mode semantic tokens — may span multiple :root/.dark blocks
+  for (const block of extractAllBlocks(css.dark, /:root[^{]*\{/)) {
+    parsePropsInto(block, 'dark', result)
   }
 
-  // Parse light mode semantic tokens
-  const lightBlock = extractBlock(css.light, /\[data-theme="light"\]\s*\{/)
-  if (lightBlock) {
-    parsePropsInto(lightBlock, 'light', result)
+  // Parse light mode semantic tokens — selector uses single quotes: [data-theme='light']
+  for (const block of extractAllBlocks(css.light, /\[data-theme=['"]light['"]\][^{]*\{/)) {
+    parsePropsInto(block, 'light', result)
   }
 
   // Resolve var() references within each mode.
@@ -47,20 +45,37 @@ export function parseCSSTokens(css: CSSFiles): Map<string, FlatToken> {
   return result
 }
 
-/** Extract the content between `{` and its matching `}` for a block. */
+/**
+ * Extract the content between `{` and its matching `}` for the first matching block.
+ * Returns null if the pattern is not found.
+ */
 function extractBlock(css: string, startPattern: RegExp): string | null {
-  const match = css.match(startPattern)
-  if (!match) return null
-  const start = css.indexOf('{', match.index!)
-  if (start === -1) return null
-  let depth = 1
-  let i = start + 1
-  while (i < css.length && depth > 0) {
-    if (css[i] === '{') depth++
-    else if (css[i] === '}') depth--
-    i++
+  const blocks = extractAllBlocks(css, startPattern)
+  return blocks.length > 0 ? blocks[0] : null
+}
+
+/**
+ * Extract the content of ALL blocks matching the given selector pattern.
+ * CSS files can have the same selector repeated (e.g. two `:root, .dark {}` blocks).
+ */
+function extractAllBlocks(css: string, startPattern: RegExp): string[] {
+  const results: string[] = []
+  const globalPattern = new RegExp(startPattern.source, 'g')
+
+  for (const match of css.matchAll(globalPattern)) {
+    const start = css.indexOf('{', match.index!)
+    if (start === -1) continue
+    let depth = 1
+    let i = start + 1
+    while (i < css.length && depth > 0) {
+      if (css[i] === '{') depth++
+      else if (css[i] === '}') depth--
+      i++
+    }
+    results.push(css.slice(start + 1, i - 1))
   }
-  return css.slice(start + 1, i - 1)
+
+  return results
 }
 
 export function modeForBaseToken(name: string): string {
@@ -275,21 +290,71 @@ const WEIGHT_NAMES: Record<string, string> = {
  * Uses `/* @figma path *​/` comment decorators when present to get the exact
  * Figma text style name. Falls back to heuristic name reconstruction when
  * no decorator is found (e.g. when fetching from an older branch).
+ *
+ * Supports `@apply text-X;` bodies — the target's properties are resolved
+ * recursively so named aliases (e.g. `text-sans-md { @apply text-sans-14; }`)
+ * produce correct values instead of empty ones.
  */
 function parseTypographyUtilities(css: string, result: Map<string, FlatToken>): void {
-  // Match @utility blocks optionally preceded by a @figma comment
-  const regex = /(?:\/\* @figma (.+?) \*\/\s*)?@utility text-([a-zA-Z0-9-]+)\s*\{([^}]+)\}/g
+  const regex = /(?:\/\* @figma (.+?) \*\/\s*)?@utility (text-[a-zA-Z0-9-]+)\s*\{([^}]+)\}/g
+
+  // --- Pass 1: collect raw bodies keyed by full utility name (e.g. "text-sans-14") ---
+  type RawBlock = { figmaPath: string | undefined; utilityName: string; body: string }
+  const rawBlocks: RawBlock[] = []
+  const bodies = new Map<string, string>() // "text-sans-14" → raw body text
 
   for (const match of css.matchAll(regex)) {
-    const figmaPath = match[1] // e.g. "mono/regular/xs" (undefined if no decorator)
-    const utilityName = match[2] // e.g. "mono-xs" or "sans-semi-sm"
+    const figmaPath = match[1]
+    const utilityName = match[2] // full name including "text-" prefix
     const body = match[3]
+    bodies.set(utilityName, body)
+    rawBlocks.push({ figmaPath, utilityName, body })
+  }
 
+  // --- Pass 2: emit tokens with @apply chains resolved ---
+
+  /** Extract declared CSS properties from a raw body string. */
+  function parseProps(body: string): Record<string, string> {
     const props: Record<string, string> = {}
     const propRegex = /([\w-]+):\s*([^;]+);/g
     for (const pm of body.matchAll(propRegex)) {
       props[pm[1]] = pm[2].trim()
     }
+    return props
+  }
+
+  /**
+   * Resolve the effective properties for a utility, following @apply chains.
+   * Direct declarations take precedence; @apply'd properties fill in the rest.
+   */
+  function resolveProps(
+    utilityName: string,
+    seen = new Set<string>(),
+  ): Record<string, string> {
+    if (seen.has(utilityName)) return {}
+    seen.add(utilityName)
+
+    const body = bodies.get(utilityName)
+    if (!body) return {}
+
+    const direct = parseProps(body)
+
+    // Merge in properties from any @apply targets (direct props win)
+    const applyRegex = /@apply\s+(text-[a-zA-Z0-9-]+)/g
+    for (const am of body.matchAll(applyRegex)) {
+      const target = am[1]
+      const inherited = resolveProps(target, new Set(seen))
+      for (const [k, v] of Object.entries(inherited)) {
+        if (!(k in direct)) direct[k] = v
+      }
+    }
+
+    return direct
+  }
+
+  for (const { figmaPath, utilityName } of rawBlocks) {
+    const shortName = utilityName.slice('text-'.length) // e.g. "sans-md" or "sans-14"
+    const props = resolveProps(utilityName)
 
     // Determine Figma name: use decorator if present, otherwise reconstruct
     let figmaName: string
@@ -298,13 +363,13 @@ function parseTypographyUtilities(css: string, result: Map<string, FlatToken>): 
     } else {
       const fontWeight = props['font-weight'] ?? '400'
       const weightName = WEIGHT_NAMES[fontWeight]
-      if (weightName && !utilityName.includes(weightName)) {
-        const parts = utilityName.split('-')
+      if (weightName && !shortName.includes(weightName)) {
+        const parts = shortName.split('-')
         const family = parts[0]
         const size = parts.slice(1).join('-')
         figmaName = `${family}.${weightName}.${size}`
       } else {
-        figmaName = utilityName.replace(/-/g, '.')
+        figmaName = shortName.replace(/-/g, '.')
       }
     }
 
@@ -314,14 +379,7 @@ function parseTypographyUtilities(css: string, result: Map<string, FlatToken>): 
     const lineHeight = props['line-height'] ?? ''
     const letterSpacing = props['letter-spacing'] ?? ''
 
-    const value = JSON.stringify({
-      fontFamily,
-      fontWeight,
-      fontSize,
-      lineHeight,
-      letterSpacing,
-    })
-
+    const value = JSON.stringify({ fontFamily, fontWeight, fontSize, lineHeight, letterSpacing })
     result.set(figmaName, { name: figmaName, value, type: 'typography' })
   }
 }


### PR DESCRIPTION
Introduces a layered typography architecture and the first responsive semantic tokens (`heading-*`). Existing `text-sans-*` callsites continue to work.

### What's new

**Three layers**

1. **Pixel-named primitives** (source of truth): `text-sans-11 / 12 / 14 / 16 / 18 / 20 / 22 / 25 / 28 / 36 / 50 / 52 / 65`. 
2. **Named aliases** (existing API): `text-sans-sm / md / lg / xl / 2xl / 3xl / 4xl / 5xl` now `@apply` the matching pixel primitive. Figma comments retained on the aliases so the Figma → code mapping stays intact. `5xl` is new (65px) to cover the marketing-scale display sizes.
3. **Responsive semantic tokens** (new): `heading-display / heading-xl / heading-lg / heading-md` step through primitives at 600 / 800 / 1000px.

**Letter-spacing curve**

All sans primitives now use `em` for letter-spacing along an optical tracking curve (`0.861 / size − 0.0383 em`). Small text opens up for legibility, display sizes tighten. Zero crossing sits around 22px. Was doing this manually previously, but this is a bit more consistent.

**Preview**

New `preview/TypographyShowcase.tsx` with a viewport-width ruler that highlights active breakpoints, plus a Components / Typography view toggle in the preview header. Resize the window to verify each heading token's steps.

<img width="1264" height="1187" alt="image" src="https://github.com/user-attachments/assets/cdcaca7d-be02-4361-ac26-464e28954fa8" />

### Not here

- Responsive body tokens, there doesn't seem to be enough consistency in the marketing site usage to infer something here.

**Canary:** `npm install @oxide/design-system@6.2.1-canary.1e4566b`