### PR TITLE
Add target utility

### DIFF
--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -173,3 +173,14 @@ Make sure disabled buttons don't get the pointer cursor.
   background-color: color-mix(in srgb, currentColor 8%, transparent);
   border-color: color-mix(in srgb, currentColor 10%, transparent);
 }
+
+/* Expands an element's hit area by N pixels on all sides via a transparent ::after overlay, without affecting layout. Usage: `target-8` adds 8px of clickable padding around the element. */
+@utility target-* {
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: calc(--value(integer) * -1px);
+  }
+}


### PR DESCRIPTION
Adds a `target-*` utility that expands an element's hit area by N pixels on all sides using a transparent `::after` overlay — useful for meeting tap-target sizes on small icon buttons without altering layout. Usage: `target-8` adds 8px of clickable padding.

**Canary:** `npm install @oxide/design-system@6.3.0-canary.97d1d97`