### PR TITLE
Memoize in-flight highlighter promise

### DIFF
--- a/components/src/asciidoc/util.ts
+++ b/components/src/asciidoc/util.ts
@@ -33,21 +33,18 @@ import oxql from './langs/oxql.tmLanguage.json'
 import p4 from './langs/p4.tmLanguage.json'
 import theme from './oxide-syntax.json'
 
-let highlighter: HighlighterGeneric<BundledLanguage, BundledTheme> | null = null
+let highlighterPromise: Promise<
+  HighlighterGeneric<BundledLanguage, BundledTheme>
+> | null = null
 const customLanguages = ['oxql', 'p4']
 const supportedLanguages = [...Object.keys(bundledLanguages), ...customLanguages]
 
-export async function getHighlighter() {
-  if (!highlighter) {
+export function getHighlighter() {
+  if (!highlighterPromise) {
     const langs: LanguageInput[] = [{ ...oxql }, { ...p4 }]
-
-    highlighter = await createHighlighter({
-      themes: [theme],
-      langs,
-    })
+    highlighterPromise = createHighlighter({ themes: [theme], langs })
   }
-
-  return highlighter
+  return highlighterPromise
 }
 
 export async function highlightCode(


### PR DESCRIPTION
`getHighlighter()` cached the resolved highlighter but not the in-flight promise, so concurrent callers (e.g. Vite's parallel `transform()` calls on `.adoc` files) each kicked off their own `createHighlighter()` until one won — we saw 300+ instances spun up before the cache settled.

Cache the promise itself so the first caller starts the work and everyone else awaits the same result.

**Canary:** `npm install @oxide/design-system@6.3.0-canary.e167166`