### PR TITLE
Set leading on pre block

### DIFF
--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -399,6 +399,7 @@
     pre {
       overflow-x: auto;
       font-size: 13px;
+      line-height: 1.5;
       letter-spacing: 0;
       text-transform: none !important;
       font-feature-settings: 'calt' 0;


### PR DESCRIPTION
This wasn't set leading (no pun intended) to unpredictable rendering depending on its context.