### PR TITLE
Docs `details` fixes

### DIFF
--- a/components/src/asciidoc/util.ts
+++ b/components/src/asciidoc/util.ts
@@ -62,12 +62,14 @@ const highlight = async (block: Block): Promise<Block> => {
   if (block.type === 'listing') {
     const literalBlock = block as LiteralBlock
 
-    // Work from `source` (raw, un-escaped block text). Highlighting re-escapes,
-    // so feeding it the specialchars-escaped `content` would double-escape
-    // (`&` -> `&amp;` -> rendered literally).
-    if (typeof literalBlock.source !== 'string') {
+    // Highlight `subbedSource`: `source` with react-asciidoc's text-level subs
+    // (notably `attributes`) resolved, but still un-escaped and with raw `<N>`
+    // callouts — the plain code to tokenize. Highlighting re-escapes, so feeding
+    // it the specialchars-escaped `content` would double-escape (`&` -> `&amp;`).
+    if (typeof literalBlock.subbedSource !== 'string') {
       return block
     }
+    const source = literalBlock.subbedSource
 
     // Turn raw callout markers (`<N>`, optionally comment-prefixed) into the
     // `<i class="conum" data-value="N"></i><b>(N)</b>` markup asciidoc.css
@@ -75,7 +77,7 @@ const highlight = async (block: Block): Promise<Block> => {
     // it runs on `source`, not the escaped `&lt;N&gt;` of `content`.
     const lineComment = literalBlock.attributes['line-comment']
     const content = Inline.subCalloutsRaw(
-      literalBlock.source,
+      source,
       true,
       lineComment !== undefined ? String(lineComment) : undefined,
     )

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -415,6 +415,7 @@
       border: 1px solid var(--stroke-secondary);
       border-radius: var(--radius-md);
       padding: 1rem 1.25rem;
+      position: relative;
 
       @media (min-width: 800px) {
         padding: 1.5rem 1.75rem;
@@ -539,7 +540,8 @@
     .stemblock,
     .videoblock,
     .exampleblock,
-    .table-wrapper {
+    .table-wrapper,
+    details {
       margin: 1rem 0;
     }
 

--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -771,8 +771,11 @@
         }
       }
 
-      &[open] summary:first-of-type::before {
-        content: '▾';
+      &[open] summary:first-of-type {
+        &::before {
+          content: '▾';
+        }
+        background-color: var(--surface-hover);
       }
 
       .content {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       },
       "peerDependencies": {
         "@asciidoctor/core": "^3.0.0",
-        "@oxide/react-asciidoc": "^2.0.0",
+        "@oxide/react-asciidoc": "^2.1.1",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       }
@@ -1449,9 +1449,9 @@
       }
     },
     "node_modules/@oxide/react-asciidoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@oxide/react-asciidoc/-/react-asciidoc-2.0.0.tgz",
-      "integrity": "sha512-NdNM9UDGtF+Tlhfj/q2eZmeWVjMcwj7f+dkXqPyJOR9Qy945fFbVMpWpoQEMcovx9rDqFC1030p0eNBFroOiGg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@oxide/react-asciidoc/-/react-asciidoc-2.1.1.tgz",
+      "integrity": "sha512-+usPUxsRsgFqUkbs98Z4HyGjjqFdaMFv4GX80NP1Jwj5sl+n4ByYw6X/L2UyG1O6XcwGeBOJGHFhYt29N7oOdg==",
       "license": "MPL 2.0",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "@asciidoctor/core": "^3.0.0",
-    "@oxide/react-asciidoc": "^2.0.0",
+    "@oxide/react-asciidoc": "^2.1.1",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },

--- a/preview/writers-guide.adoc
+++ b/preview/writers-guide.adoc
@@ -38,6 +38,11 @@ endif::[]
 This guide provides a gentle introduction to AsciiDoc, a _plain text_ documentation *syntax* and *processor*.
 This introduction is intended for anyone who wants to reduce the effort required to write and publish content, whether for technical documentation, articles, web pages or good ol'-fashioned prose.
 
+[%collapsible]
+====
+This content is only revealed when the user clicks the block title.
+====
+
 TIP: If you want to know what AsciiDoc is all about, find the answer in {url-docs-asciidoc}#about-asciidoc[About AsciiDoc].
 If you're looking for a concise survey of the AsciiDoc syntax, consult the {url-quickref}[AsciiDoc Syntax Quick Reference].
 

--- a/test/asciidoc.test.tsx
+++ b/test/asciidoc.test.tsx
@@ -146,6 +146,37 @@ describe('callouts + syntax highlighting', () => {
     expect(html).toContain('<i class="conum" data-value="1"></i><b>(1)</b>')
   })
 
+  it('substitutes attribute refs in a highlighted source block that opts in', async () => {
+    const html = await renderHighlighted(
+      `:api-version: 2026032500.0.0\n\n[source,text,subs="+attributes"]\n----\napi-version: {api-version}\n----`,
+    )
+    expect(html).toContain('2026032500.0.0')
+    expect(html).not.toContain('{api-version}')
+  })
+
+  it('leaves brace tokens literal in a source block that does not opt in', async () => {
+    const html = await renderHighlighted(
+      `:api-version: 2026032500.0.0\n\n[source,bash]\n----\necho "{api-version}"\n----`,
+    )
+    expect(html).toContain('{api-version}')
+    expect(html).not.toContain('2026032500.0.0')
+  })
+
+  it('handles attribute subs and callouts together in a highlighted listing', async () => {
+    const html = await renderHighlighted(
+      `:api-version: 2026032500.0.0\n\n[source,javascript,subs="+attributes"]\n----\nconst version = "{api-version}" // <1>\n----\n<1> the API version`,
+    )
+    expect(html).toContain('language-javascript')
+    // the attribute ref is resolved...
+    expect(html).toContain('2026032500.0.0')
+    expect(html).not.toContain('{api-version}')
+    // ...and the callout survives as conum markup, not escaped visible text
+    expect(html).toContain('<i class="conum" data-value="1"></i><b>(1)</b>')
+    expect(html).not.toContain('&#x3C;b&#x3E;')
+    // the comment prefix is dropped, not left dangling before the conum
+    expect(html).not.toMatch(/\/\/\s*<i class="conum"/)
+  })
+
   it('renders inline icon: macros as font icons (icons=font)', () => {
     const html = render('An inline icon:heart[] here.')
     expect(html).toContain('class="icon"')


### PR DESCRIPTION
Fix glitched absolute position inside details block and add a margin

<img width="685" height="387" alt="image" src="https://github.com/user-attachments/assets/e75b34fc-ec82-4bb9-bcbd-e476930b7209" />

**Canary:** `npm install @oxide/design-system@6.5.0-canary.8ce729e`