### PR TITLE
Only apply text style to ol/ul markers

### DIFF
--- a/components/src/assets/asciidoc.css
+++ b/components/src/assets/asciidoc.css
@@ -158,7 +158,6 @@
     /* --- Lists --- */
     ul,
     ol {
-      @apply text-mono-sm;
       margin-bottom: 0.75rem;
       list-style-position: inside;
 
@@ -206,6 +205,10 @@
     ul li,
     ol li {
       margin-top: 0.325rem;
+
+      &::marker {
+        @apply text-mono-sm;
+      }
     }
 
     li::marker {


### PR DESCRIPTION
The text style that I was using on the markers was messing with nested admonition blocks. Instead I'm using a more granular selector to avoid it leaking.

Fixes #200 

**Canary:** `npm install @oxide/design-system@6.5.2-canary.5f5c350`