### PR TITLE
asciidoc: render block anchor for admonitions

### DIFF
--- a/components/src/asciidoc/Admonition.tsx
+++ b/components/src/asciidoc/Admonition.tsx
@@ -32,6 +32,7 @@ const Admonition = ({ node }: { node: AdmonitionBlock }) => {
 
   return (
     <div className={`admonitionblock ${attrs.name} ${theme}`}>
+      {node.id && <span className="anchor" id={node.id} aria-hidden="true" />}
       <div className="admonition-icon">{icon}</div>
       <div className="admonition-content content">
         <div>{titleCase(attrs.name.toString())}</div>

--- a/test/asciidoc.test.tsx
+++ b/test/asciidoc.test.tsx
@@ -71,6 +71,16 @@ describe('Admonition', () => {
     expect(html).toContain('Body here.')
     expect(html).not.toContain('fa icon-tip')
   })
+
+  it('renders a hidden anchor span when the block has an id', () => {
+    const html = render(`[[my-anchor]]\n[NOTE]\nBody here.`)
+    expect(html).toContain('<span class="anchor" id="my-anchor" aria-hidden="true">')
+  })
+
+  it('renders no anchor span when the block has no id', () => {
+    const html = render(`[NOTE]\nBody here.`)
+    expect(html).not.toContain('class="anchor"')
+  })
 })
 
 describe('Section', () => {


### PR DESCRIPTION
An admonition with a block id (`[[my-anchor]]`) renders no anchor target, so cross-references and #links to it scrolled nowhere. We fix this by emitting the same hidden anchor span that Section uses.